### PR TITLE
Support for user-configured code collections

### DIFF
--- a/src/VERSION
+++ b/src/VERSION
@@ -1,4 +1,4 @@
 {
   "name":    "runwhen-local",
-  "version": "0.2.0"
+  "version": "0.2.1"
 }

--- a/src/default-code-collections.yaml
+++ b/src/default-code-collections.yaml
@@ -1,4 +1,2 @@
-version: "0.1"
-codeCollections:
 - https://github.com/runwhen-contrib/rw-public-codecollection.git
 - https://github.com/runwhen-contrib/rw-cli-codecollection.git

--- a/src/enrichers/code_collection.py
+++ b/src/enrichers/code_collection.py
@@ -110,7 +110,8 @@ class CodeBundleConfig:
 
 CODE_BUNDLE_CONFIG_DEFAULTS = CodeBundleConfig(PatternType.GLOB, None, True, None,
                                                StringMatchMode.SUBSTRING, CodeCollectionAction.INCLUDE)
-
+CODE_BUNDLE_CONFIG_INCLUDE_ALL = CodeBundleConfig(PatternType.GLOB, "*", True, None,
+                                                  StringMatchMode.EXACT, CodeCollectionAction.INCLUDE)
 @dataclass
 class CodeCollectionConfig:
     """
@@ -134,7 +135,7 @@ class CodeCollectionConfig:
             auth_token = None
             ref_name = "main"
             action = CodeCollectionAction.INCLUDE
-            code_bundle_configs = ["*"]
+            code_bundle_configs = [CODE_BUNDLE_CONFIG_INCLUDE_ALL]
         else:
             repo_url = code_collection_config.get("repoURL")
             if repo_url is None:
@@ -342,17 +343,11 @@ def init_code_collections():
     # Load in the default/built-in code collections
     with open(DEFAULT_CODE_COLLECTIONS_FILE_NAME, "r") as f:
         code_collections_config_text = f.read()
-    code_collections_config = yaml.safe_load(code_collections_config_text)
-    version = code_collections_config.get("version")
-    if version != CURRENT_CODE_COLLECTIONS_CONFIG_VERSION:
-        # If/when we change the format/version we could do conversion from older versions here
-        raise WorkspaceBuilderException(f"Unsupported code collection config version: {version}. "
-                                        f"Current/supported version is {CURRENT_CODE_COLLECTIONS_CONFIG_VERSION}")
-    code_collection_config_list = code_collections_config.get("codeCollections", [])
+    code_collections_configs_data = yaml.safe_load(code_collections_config_text)
 
     global default_code_collection_configs
     default_code_collection_configs = []
-    for ccc in code_collection_config_list:
+    for ccc in code_collections_configs_data:
         code_collection_config = CodeCollectionConfig.construct_from_config(ccc)
         # NB: It's not a normal case that one of the default code collection
         # entries would be set to EXCLUDE (i.e. instead of just removing it),

--- a/src/enrichers/generation_rules.py
+++ b/src/enrichers/generation_rules.py
@@ -817,7 +817,7 @@ def load(context: Context) -> None:
         code_collection = get_code_collection(code_collection_config)
         ref_name = code_collection_config.ref_name
         code_collection.update_repo(ref_name)
-        code_bundle_names = code_collection.get_code_bundle_names(ref_name)
+        code_bundle_names = code_collection.get_code_bundle_names(ref_name, code_collection_config)
         for code_bundle_name in code_bundle_names:
             if code_bundle_name == "k8s-kubectl-namespace-healthcheck":
                 x = 0

--- a/src/run.py
+++ b/src/run.py
@@ -192,11 +192,13 @@ def main():
         namespace_lods = workspace_info.get('namespaceLODs')
         custom_definitions = workspace_info.get("custom", dict())
         personas = workspace_info.get("personas", dict())
+        code_collections = workspace_info.get("codeCollections")
     else:
         upload_token = None
         namespace_lods = None
         custom_definitions = dict()
         personas = dict()
+        code_collections = None
 
     # If a setting has still not been set, try an environment variable as a last resort
     # FIXME: With the switch to having default values for the command line args, these
@@ -314,6 +316,8 @@ def main():
             request_data['personas'] = personas
         if namespaces:
             request_data['namespaces'] = namespaces
+        if code_collections:
+            request_data['codeCollections'] = code_collections
 
         # Update cheat sheet status by copying index
         shutil.copyfile("cheat-sheet-docs/templates/index-status-discovery.md", "cheat-sheet-docs/docs/index.md")

--- a/src/tests.py
+++ b/src/tests.py
@@ -1,12 +1,14 @@
 from io import BytesIO
+import git
 import os
 import tempfile
+import shutil
 import tarfile
+import yaml
 
 from exceptions import (
     WorkspaceBuilderException,
     WorkspaceBuilderUserException,
-    InvalidGitRepoURLException,
     INVALID_GIT_REPO_MESSAGE
 )
 from name_utils import make_qualified_slx_name, make_slx_name, shorten_name
@@ -15,6 +17,13 @@ from git_utils import (
     get_repo_url_with_auth,
     create_repo_directory,
     CREATE_REPO_DIRECTORY_NO_AVAILABLE_NAME_MESSAGE
+)
+from enrichers.code_collection import (
+    CodeCollectionConfig,
+    CodeBundleConfig,
+    CodeCollectionAction,
+    StringMatchMode,
+    PatternType,
 )
 
 from unittest import TestCase
@@ -35,7 +44,8 @@ class OutputterTest(TestCase):
     def tearDown(self):
         self.output_dir.cleanup()
 
-    def common_write_files(self, outputter: Outputter):
+    @staticmethod
+    def common_write_files(outputter: Outputter):
         for path, data in OutputterTest.TEST_FILES:
             outputter.write_file(path, data)
 
@@ -128,7 +138,6 @@ class RepoUtilsTest(TestCase):
         self.assertIn(invalid_repo_url, message)
 
     def test_get_repo_with_auth(self):
-        repo_url = "https://github.com/foo/bar.git"
         auth_url = get_repo_url_with_auth("https://github.com/foo/bar.git", "", "")
         self.assertEqual("https://github.com/foo/bar.git", auth_url)
         auth_url = get_repo_url_with_auth("https://github.com/foo/bar.git", "", "abc")
@@ -153,3 +162,194 @@ class RepoUtilsTest(TestCase):
         self.assertIn(CREATE_REPO_DIRECTORY_NO_AVAILABLE_NAME_MESSAGE, message)
         self.assertIn(repo_name, message)
 
+TEST_DATA_DIRECTORY = "test-data"
+
+
+
+TEST_WHITE_LIST_CODE_COLLECTION_CONFIG = """
+repoURL: file:///dummy/cc.git
+codeBundles: [cert, k8s, git]
+"""
+
+TEST_BLACK_LIST_CODE_COLLECTION_CONFIG_1 = """
+repoURL: file:///dummy/cc.git
+codeBundles: ["!k8s", "!cortex", "*"]
+"""
+
+TEST_BLACK_LIST_CODE_COLLECTION_CONFIG_2 = """
+repoURL: file:///dummy/cc.git
+codeBundleMatchDefaults:
+  action: exclude
+codeBundles: ["k8s", "cortex", {"pattern": "*", "action": "include"}]
+"""
+
+class CodeCollectionConfigTestCase(TestCase):
+
+    def check_code_bundle_config(self,
+                                 code_bundle_config: CodeBundleConfig,
+                                 expected_pattern_type: PatternType,
+                                 expected_ignore_case: bool,
+                                 expected_pattern_string: str,
+                                 expected_match_mode: StringMatchMode,
+                                 expected_action: CodeCollectionAction):
+        self.assertEqual(code_bundle_config.pattern_type, expected_pattern_type, "pattern_type")
+        self.assertEqual(expected_ignore_case, code_bundle_config.ignore_case, "ignore_case")
+        self.assertEqual(expected_pattern_string, code_bundle_config.pattern_string, "pattern")
+        self.assertEqual(expected_match_mode, code_bundle_config.match_mode, "match_mode")
+        self.assertEqual(expected_action, code_bundle_config.action, "action")
+
+    def parse_code_bundle_config_common(self,
+                                  code_bundle_config_data : Union[str, dict[str,str]],
+                                  expected_pattern_type: PatternType,
+                                  expected_ignore_case: bool,
+                                  expected_pattern_string: str,
+                                  expected_match_mode: StringMatchMode,
+                                  expected_action: CodeCollectionAction,
+                                  code_bundle_match_defaults: CodeBundleConfig = None):
+        code_bundle_config = CodeBundleConfig.construct_from_config(code_bundle_config_data, code_bundle_match_defaults)
+        self.check_code_bundle_config(code_bundle_config, expected_pattern_type, expected_ignore_case,
+                                      expected_pattern_string, expected_match_mode, expected_action)
+
+    def test_parse_code_bundle_config(self):
+        code_bundle_config_data = {
+            "patternType": "literal",
+            "ignoreCase": True,
+            "pattern": "foobar",
+            "matchMode": "exact",
+            "action": "include"
+        }
+        for pattern_type in PatternType:
+            code_bundle_config_data["patternType"] = pattern_type.value
+            self.parse_code_bundle_config_common(code_bundle_config_data, pattern_type, True, "foobar",
+                                                 StringMatchMode.EXACT, CodeCollectionAction.INCLUDE)
+        code_bundle_config_data["patternType"] = "literal"
+
+        for match_mode in StringMatchMode:
+            code_bundle_config_data["matchMode"] = match_mode.value
+            self.parse_code_bundle_config_common(code_bundle_config_data, PatternType.LITERAL, True, "foobar",
+                                                 match_mode, CodeCollectionAction.INCLUDE)
+        code_bundle_config_data["matchMode"] = "exact"
+
+        for action in CodeCollectionAction:
+            code_bundle_config_data["action"] = action.value
+            self.parse_code_bundle_config_common(code_bundle_config_data, PatternType.LITERAL, True, "foobar",
+                                                 StringMatchMode.EXACT, action)
+
+    def test_parse_code_bundle_config_string(self):
+        code_bundle_config = CodeBundleConfig.construct_from_config("cortex")
+        self.check_code_bundle_config(code_bundle_config, PatternType.GLOB, True, "cortex",
+                                      StringMatchMode.SUBSTRING, CodeCollectionAction.INCLUDE)
+        code_bundle_config = CodeBundleConfig.construct_from_config("!*cortex")
+        self.check_code_bundle_config(code_bundle_config, PatternType.GLOB, True, "*cortex",
+                                      StringMatchMode.SUBSTRING, CodeCollectionAction.EXCLUDE)
+
+    def test_parse_code_bundle_config_with_defaults(self):
+        defaults = CodeBundleConfig(PatternType.REGEX, None, False, None,
+                                    StringMatchMode.EXACT, CodeCollectionAction.EXCLUDE)
+
+    def assert_code_bundle_config_includes(self, code_bundle_config_data: Union[str,dict],
+                                           code_bundle_name: str,
+                                           expected_match_result: bool):
+        code_bundle_config = CodeBundleConfig.construct_from_config(code_bundle_config_data)
+        match_result = code_bundle_config.matches_code_bundle_name(code_bundle_name)
+        self.assertEqual(expected_match_result, match_result)
+
+    def test_literal_pattern(self):
+        code_bundle_config = {
+            "patternType": "literal",
+            "ignoreCase": True,
+            "pattern": "bb",
+            "matchMode": "exact",
+            "action": "include"
+        }
+        self.assert_code_bundle_config_includes(code_bundle_config, "bb", True)
+        self.assert_code_bundle_config_includes(code_bundle_config, "BB", True)
+        self.assert_code_bundle_config_includes(code_bundle_config, "bbc", False)
+        code_bundle_config["ignoreCase"] = False
+        self.assert_code_bundle_config_includes(code_bundle_config, "BB", False)
+        code_bundle_config["matchMode"] = "substring"
+        self.assert_code_bundle_config_includes(code_bundle_config, "bbc", True)
+
+    def test_glob_pattern(self):
+        code_bundle_config = {
+            "patternType": "glob",
+            "ignoreCase": True,
+            "pattern": "b*b",
+            "matchMode": "exact",
+            "action": "include"
+        }
+        self.assert_code_bundle_config_includes(code_bundle_config, "bb", True)
+        self.assert_code_bundle_config_includes(code_bundle_config, "baaaab", True)
+        self.assert_code_bundle_config_includes(code_bundle_config, "cccbaaaab", False)
+        self.assert_code_bundle_config_includes(code_bundle_config, "Baaaab", True)
+        code_bundle_config["ignoreCase"] = False
+        self.assert_code_bundle_config_includes(code_bundle_config, "Baaaab", False)
+        code_bundle_config["matchMode"] = "substring"
+        self.assert_code_bundle_config_includes(code_bundle_config, "cccbaaaab", True)
+
+    def test_regex_pattern(self):
+        code_bundle_config = {
+            "patternType": "regex",
+            "ignoreCase": True,
+            "pattern": "b[def]+b",
+            "matchMode": "exact",
+            "action": "include"
+        }
+        self.assert_code_bundle_config_includes(code_bundle_config, "bdb", True)
+        self.assert_code_bundle_config_includes(code_bundle_config, "bddffeeb", True)
+        self.assert_code_bundle_config_includes(code_bundle_config, "BdDFfeEb", True)
+        self.assert_code_bundle_config_includes(code_bundle_config, "cccbdefb", False)
+        code_bundle_config["ignoreCase"] = False
+        self.assert_code_bundle_config_includes(code_bundle_config, "Bdefb", False)
+        code_bundle_config["matchMode"] = "substring"
+        self.assert_code_bundle_config_includes(code_bundle_config, "cccbdefb", True)
+
+    def code_bundle_inclusion_common(self, code_collection_config_data: Union[str,dict],
+                                     included_code_bundles: list[str],
+                                     excluded_code_bundles: list[str]):
+        if isinstance(code_collection_config_data, str):
+            code_collection_config_data = yaml.safe_load(code_collection_config_data)
+        code_collection_config = CodeCollectionConfig.construct_from_config(code_collection_config_data)
+        for code_bundle_name in included_code_bundles:
+            self.assertTrue(code_collection_config.is_included_code_bundle(code_bundle_name), code_bundle_name)
+        for code_bundle_name in excluded_code_bundles:
+            self.assertFalse(code_collection_config.is_included_code_bundle(code_bundle_name), code_bundle_name)
+
+    def test_code_bundle_white_list(self):
+        included_code_bundles = ["cert-manager-health", "git-status", "k8s-namespace-health"]
+        excluded_code_bundles = ['cortex-health', "aws-test"]
+        self.code_bundle_inclusion_common(TEST_WHITE_LIST_CODE_COLLECTION_CONFIG,
+                                          included_code_bundles,
+                                          excluded_code_bundles)
+
+    def test_code_bundle_black_list(self):
+        included_code_bundles = ["cert-manager-health", "git-status"]
+        excluded_code_bundles = ['k8s-namespace-health', "cortex-status"]
+        self.code_bundle_inclusion_common(TEST_BLACK_LIST_CODE_COLLECTION_CONFIG_1,
+                                          included_code_bundles,
+                                          excluded_code_bundles)
+        self.code_bundle_inclusion_common(TEST_BLACK_LIST_CODE_COLLECTION_CONFIG_2,
+                                          included_code_bundles,
+                                          excluded_code_bundles)
+
+# class CodeBundleInclusionTestCase(TestCase):
+#
+#     def setUp(self):
+#         self.local_repo_dir = tempfile.TemporaryDirectory()
+#
+#     def tearDown(self):
+#         self.local_repo_dir.cleanup()
+#
+#     def init_local_repo_from_fixture(self, fixture_name) -> str:
+#         # Check if the fixture exists in the test data directory
+#         fixture_dir = os.path.join(TEST_DATA_DIRECTORY, fixture_name)
+#         local_repo_dir = self.local_repo_dir.name
+#         local_repo_url = f"file://{local_repo_dir}"
+#         shutil.copytree(fixture_dir, local_repo_dir)
+#         local_repo = git.Repo.init(local_repo_url, b="main")
+#         local_repo.git.add(all=True)
+#         local_repo.index.commit("Initial commit")
+#         return local_repo_url
+#
+#     def test_no_code_bundle_config(self):
+#         pass

--- a/src/workspace_builder/tests.py
+++ b/src/workspace_builder/tests.py
@@ -55,7 +55,7 @@ BASE_REQUEST_DATA = {
     #     }
     # }
     "codeCollections": [
-        {"repoURL": f"file://{git_repo_root}/rw-public-codecollection", "branch": "main"},
+        {"repoURL": f"file://{git_repo_root}/rw-public-codecollection", "branch": "main", "codeBundles": ["*"]},
         {"repoURL": f"file://{git_repo_root}/rw-cli-codecollection", "branch": "main"}
     ]
 }


### PR DESCRIPTION
- allows the user to override the default set of code collections that are scanned for gen rules
- the code collections are specified in the workspaceInfo file using a field named (unsurprisingly) "codeCollections" that is a list of the code collection spec
- if you don't want to scan all of the code bundles in the code collection the code collection spec can just be a string that's the git URL for the code collection
- if you need to use other options for the code collections, then the code collection is a dict with the following supported fields:
  - "repoURL": the git repo URL for the code collection
  - "authUser": the user credential to use when accessing the repo
  - "authToken": the token credential to use when accessing the repo
  - "ref": the git ref name to use in the repo
  - "branch": the git branch to use in the repo
  - "tag": the git tag to use in the repo
  - "codeBundles": code bundle match specs (described below) to control when code bundles are scanned in the code collection
- at most one of the "ref", "branch" and "tag" fields should be specified. If none of them are specified, then the "main" branch is used
- the authUser and authToken fields are only required if it's a non-public repo (currently not an issue since all of the available code collections are public)
- the "codeBundles" field is a list of code bundle match specs that are used to filter which code bundles are enabled for scanning for gen rules
- in the simplest case where you just want to white list the code bundles to include the list is just a list of string that are the patterns to search for for inclusion. The default format of the pattern is the file globbing format (e.g. "*health"). By default it does a substring match so you don't need to include leading/trailing stars.
- if you start the code bundle spec string with a ! character, then the sense of the rule is reversed and it becomes an exclusion rule. This is useful if you want to specify a blacklist to suppress certain code bundles from being included. So it would be something like this: "codeBundles": ["!health", "!opssuite", "*"]
- note that in the blacklist case you need to include the last * catchall rule case to match/include the other code bundles that don't match the exclusion rules. Also you need to use the string quotes around the exclusion rules or the yaml parser will be confused by the ! char.
- the code bundle rules also support literal and regex patterns and a number of other features. I'll write up some real documentation with better descriptions of how those more advanced features work.