### PR TITLE
Support for slash escapes in match predicate paths

### DIFF
--- a/src/cheat-sheet-docs/mkdocs.yml
+++ b/src/cheat-sheet-docs/mkdocs.yml
@@ -52,7 +52,7 @@ theme:
 build:
     date: today
     version: 0.1
-    scan_date: 2023-06-28 20:48:55
+    scan_date: today
     demo: false
 extra_css:
   - css/custom.css

--- a/src/enrichers/match_predicate.py
+++ b/src/enrichers/match_predicate.py
@@ -140,8 +140,17 @@ def base_construct_match_predicate_from_config(predicate_config: dict[str, Any],
     return match_predicate
 
 
-def path_to_components(path: str) -> list[str]:
-    return path.split('/')
+def path_to_components(path: str, separator_char=None) -> list[str]:
+    if separator_char:
+        components = path.split(separator_char)
+    elif path.find('//') >= 0:
+        slash_replacement = "!$^]"
+        path = path.replace('//', slash_replacement)
+        components = path.split('/')
+        components = [component.replace(slash_replacement, '/') for component in components]
+    else:
+        components = path.split('/')
+    return components
 
 
 def _match_resource_path(data, path_components: list[str], match_func) -> bool:

--- a/src/tests.py
+++ b/src/tests.py
@@ -18,6 +18,7 @@ from git_utils import (
     create_repo_directory,
     CREATE_REPO_DIRECTORY_NO_AVAILABLE_NAME_MESSAGE
 )
+from enrichers import match_predicate
 from enrichers.code_collection import (
     CodeCollectionConfig,
     CodeBundleConfig,
@@ -99,6 +100,21 @@ class OutputterTest(TestCase):
             self.assertIsInstance(item, FileItem)
             return item.data
         self.common_check_output(get_data)
+
+
+class PathTest(TestCase):
+
+    def test_simple_path(self):
+        components = match_predicate.path_to_components("foo/bar/abc")
+        self.assertListEqual(["foo", "bar", "abc"], components)
+
+    def test_path_with_escaped_slashes(self):
+        components = match_predicate.path_to_components("foo/bar/abc//def")
+        self.assertListEqual(["foo", "bar", "abc/def"], components)
+
+    def test_path_with_custom_separator_char(self):
+        components = match_predicate.path_to_components("foo|bar|abc/def", separator_char='|')
+        self.assertListEqual(["foo", "bar", "abc/def"], components)
 
 
 class NameUtilsTest(TestCase):


### PR DESCRIPTION
- this is to handle the case where there's a component in a path that itself contains slash characters that we don't want to be interpreted as path separator characters
- the syntax is to use a double-slash, '//', in the path if you don't want it to be treated as a path separator char

The implementation is a little hacky for now to avoid writing more complicated scanning and escape processing logic, but it should be fine for the types of paths that will be used in gen rules.

