### PR TITLE
add env vars for upload support

### DIFF
--- a/src/entrypoint.sh
+++ b/src/entrypoint.sh
@@ -59,7 +59,20 @@ then
     echo "AUTORUN_WORKSPACE_BUILDER_INTERVAL is set. Running workspace-builder"
     python manage.py runserver 0.0.0.0:8000 --noreload &
     sleep 60
-    while true; do ./run.sh; sleep $AUTORUN_WORKSPACE_BUILDER_INTERVAL; done
+    if [[ "${RW_LOCAL_UPLOAD_ENABLED,,}" == "true" ]]; 
+    then
+        echo "Upload to RunWhen Platform Enabled"
+        if [[ "$RW_LOCAL_UPLOAD_MERGE_MODE" == "keep-uploaded" ]]; 
+        then
+            echo "Merge Mode: keep-uploaded"
+            while true; do ./run.sh --upload --upload-merge-mode keep-uploaded; sleep $AUTORUN_WORKSPACE_BUILDER_INTERVAL; done
+        else
+            echo "Merge Mode: keep-existing"
+            while true; do ./run.sh --upload --upload-merge-mode keep-existing; sleep $AUTORUN_WORKSPACE_BUILDER_INTERVAL; done
+        fi
+    else
+        while true; do ./run.sh; sleep $AUTORUN_WORKSPACE_BUILDER_INTERVAL; done
+    fi 
 else
     python manage.py runserver 0.0.0.0:8000 --noreload
 fi


### PR DESCRIPTION
Introduces: 
- RW_LOCAL_UPLOAD_ENABLED
- RW_LOCAL_UPLOAD_MERGE_MODE

These support automatic upload to a RunWhen Platform Workspace - ensuring that new resources in a cluster are automatically discovered and added to the workspace. Supported in helm chart version 0.0.20, but can easily be added to any deployment manifest or through docker environment variables. 

e.g.
`docker run --name RunWhenLocal -p 8081:8081 -e AUTORUN_WORKSPACE_BUILDER_INTERVAL=300 -e RW_LOCAL_UPLOAD_ENABLED=true  -e RW_LOCAL_UPLOAD_MERGE_MODE="keep-uploaded" -e RW_LOCAL_TERMINAL_DISABLED=false -v $workdir/shared:/shared -d ghcr.io/runwhen-contrib/runwhen-local:latest`