### PR TITLE
update in cluster auth script

### DIFF
--- a/src/VERSION
+++ b/src/VERSION
@@ -1,4 +1,4 @@
 {
   "name":    "runwhen-local",
-  "version": "0.3.8"
+  "version": "0.3.9"
 }

--- a/src/scripts/in_cluster_auth_gen_kubeconfig.sh
+++ b/src/scripts/in_cluster_auth_gen_kubeconfig.sh
@@ -7,8 +7,19 @@ NEW_KUBECONFIG_FILE="/shared/generated-kubeconfig.yaml"
 NAMESPACE=$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace)
 SERVICE_ACCOUNT=$(kubectl get pods $HOSTNAME -o=jsonpath='{.spec.serviceAccountName}')
 
+# Validate namespace
+if [[ -z "$NAMESPACE" ]]; then
+    echo "Can't determine namespace details"
+    exit 1
+fi
 
-# Check if the server details and secret name are provided
+# Validate Service Account
+if [[ -z "$SERVICE_ACCOUNT" ]]; then
+    echo "Can't determine service account name"
+    exit 1
+fi
+
+# Check if the server details aare provided
 if [[ -z "$SERVER_DETAILS" ]]; then
     echo "Please provide the server details."
     exit 1

--- a/src/scripts/in_cluster_auth_gen_kubeconfig.sh
+++ b/src/scripts/in_cluster_auth_gen_kubeconfig.sh
@@ -4,10 +4,13 @@
 SERVER_DETAILS="$1"
 KUBECONFIG_FILE="/shared/in_cluster_kubeconfig.yaml"
 NEW_KUBECONFIG_FILE="/shared/generated-kubeconfig.yaml"
+NAMESPACE=$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace)
+SERVICE_ACCOUNT=$(kubectl get pods $HOSTNAME -o=jsonpath='{.spec.serviceAccountName}')
 
-# Check if the server details are provided
+
+# Check if the server details and secret name are provided
 if [[ -z "$SERVER_DETAILS" ]]; then
-    echo "Please provide the server details as an argument."
+    echo "Please provide the server details."
     exit 1
 fi
 
@@ -18,7 +21,7 @@ if grep -q "certificate-authority:" "$KUBECONFIG_FILE"; then
         # Embed the CA certificate
         CA_CERT_CONTENT=$(base64 -w 0 "$CA_CERT_PATH")
         # Substitute server details and embed the CA certificate
-        sed -e "s|^  server:.*|  server: $SERVER_DETAILS|" \
+        sed -e "s|^    server:.*|    server: $SERVER_DETAILS|" \
             -e "/certificate-authority:/a \    certificate-authority-data: $CA_CERT_CONTENT" \
             -e "/certificate-authority:/d" \
             "$KUBECONFIG_FILE" > "$NEW_KUBECONFIG_FILE"
@@ -28,13 +31,22 @@ if grep -q "certificate-authority:" "$KUBECONFIG_FILE"; then
     fi
 else
     # If certificate-authority-data is already present, just update server details
-    sed "s|^  server:.*|  server: $SERVER_DETAILS|" "$KUBECONFIG_FILE" > "$NEW_KUBECONFIG_FILE"
+    sed "s|^    server:.*|    server: $SERVER_DETAILS|" "$KUBECONFIG_FILE" > "$NEW_KUBECONFIG_FILE"
+fi
+
+# Replace the user token with the contents of the secret
+SECRET_DATA=$(kubectl get secret "$SERVICE_ACCOUNT-token" -o jsonpath='{.data.token}' | base64 -d)
+if [[ -n "$SECRET_DATA" ]]; then
+    sed -i "s|^    token:.*|    token: $SECRET_DATA|" "$NEW_KUBECONFIG_FILE"
+else
+    echo "Failed to retrieve token from the secret."
+    exit 1
 fi
 
 echo "Modified kubeconfig saved to $NEW_KUBECONFIG_FILE"
 
 # Validate the kubeconfig
-if kubectl --kubeconfig="$NEW_KUBECONFIG_FILE" get ns > /dev/null 2>&1; then
+if timeout 10s kubectl --kubeconfig="$NEW_KUBECONFIG_FILE" get ns > /dev/null 2>&1; then
     echo "Kubeconfig is valid!"
 else
     echo "Kubeconfig validation failed."


### PR DESCRIPTION
Fixes https://github.com/runwhen-contrib/runwhen-local/issues/353

- adds timeout around kubeconfig validation 
- fixes server indentation issue
- fetches long-lived secret token instead of short-lived in-pod token