### PR TITLE
adds pvc indexing

### DIFF
--- a/src/enrichers/generation_rules.py
+++ b/src/enrichers/generation_rules.py
@@ -116,6 +116,7 @@ class ResourceType(Enum):
     STATEFUL_SET = "statefulset"
     POD = "pod"
     CUSTOM = "custom"
+    PVC = "persistentvolumeclaim"
 
 
 class ResourceTypeSpec:
@@ -208,6 +209,8 @@ resource_map: dict[ResourceType, tuple[str, str]] = {
     ResourceType.DAEMON_SET: (KUBERNETES_PLATFORM, KubernetesResourceType.DAEMON_SET.value),
     ResourceType.STATEFUL_SET: (KUBERNETES_PLATFORM, KubernetesResourceType.STATEFUL_SET.value),
     ResourceType.POD: (KUBERNETES_PLATFORM, KubernetesResourceType.POD.value),
+    ResourceType.PVC: (KUBERNETES_PLATFORM, KubernetesResourceType.PVC.value),
+
 }
 
 

--- a/src/indexers/kubeapi_parsers.py
+++ b/src/indexers/kubeapi_parsers.py
@@ -90,6 +90,9 @@ def parse_pod(resource):
     ret = parse_namespaced_resource(resource)
     return ret
 
+def parse_pvc(resource):
+    ret = parse_namespaced_resource(resource)
+    return ret
 
 def parse_custom_resource_common(resource):
     # Annoyingly, the results from the call to list the custom resources returns

--- a/src/indexers/kubetypes.py
+++ b/src/indexers/kubetypes.py
@@ -26,6 +26,7 @@ class ResourceType(Enum):
     SERVICE = "service"
     POD = "pod"
     CUSTOM = "custom"
+    PVC = "persistentvolumeclaim"
 
 
 def check_kubernetes_resource(resource: Resource):

--- a/src/renderers/dump_resources.py
+++ b/src/renderers/dump_resources.py
@@ -49,6 +49,7 @@ def render(context: Context):
         cluster_dump['statefulSets'] = _dump_resource_state(registry, ResourceType.STATEFUL_SET.value, cluster_name)
         cluster_dump['daemonSets'] = _dump_resource_state(registry, ResourceType.DAEMON_SET.value, cluster_name)
         cluster_dump['pods'] = _dump_resource_state(registry, ResourceType.POD.value, cluster_name)
+        cluster_dump['pvcs'] = _dump_resource_state(registry, ResourceType.PVC.value, cluster_name)
 
     dump_text = yaml.safe_dump(dump)
     context.outputter.write_file("resource-dump.yaml", dump_text)


### PR DESCRIPTION
Previous indexing didn't support matching for persistentvolumeclaims. We simply used genrules to attach PVC troubleshooting commands to each namespace, regardless if there was a PVC or not. We now can index whether a pvc exists and then provide the necessary troubleshooting rules, further allowing newer codebundles to target specific configuration items like storage annotations, storage types, and so on.