### PR TITLE
Fixed bug with resources not being scoped with their parent in the registry

### DIFF
--- a/src/enrichers/runwhen_default_workspace.py
+++ b/src/enrichers/runwhen_default_workspace.py
@@ -40,4 +40,5 @@ def enrich(context: Context):
         workspace = registry.add_resource(RUNWHEN_PLATFORM,
                                           RunWhenResourceType.WORKSPACE.value,
                                           workspace_name,
+                                          workspace_name,
                                           workspace_attributes)

--- a/src/workspace_builder/tests.py
+++ b/src/workspace_builder/tests.py
@@ -22,44 +22,27 @@ if not git_repo_root:
 
 
 BASE_REQUEST_DATA = {
-    "namespaceLODs": {"kube-system": 0, "kube-public": 0, 'online-boutique': 2},
-    "defaultLOD": 0,
+    "namespaceLODs": {"kube-system": 0, "kube-public": 0},
+    "defaultLOD": 2,
     "defaultWorkspaceName": "my-workspace",
     "workspaceName": "my-workspace",
     "workspaceOwnerEmail": "test@runwhen.com",
-    "kubeconfig": "kubeconfig-shea",
+    "kubeconfig": "kubeconfig",
     "workspaceOutputPath": "workspace",
     "defaultLocation": "northamerica-northeast2-01",
     "mapCustomizationRules": "map-customization-rules-test",
     # "namespaces": ["cert-manager", "vault", "runwhen-local", "artifactory", "kube-system"],
-    # "namespaces": ["online-boutique"],
-    "customDefinitions": {
-        "foo": "Hello",
-        "bar": 3456,
-    },
-    # "personas": {
-    #     "eager-edgar": {
-    #         "search": {
-    #             "promptStrategy": "dummy",
-    #             "x": 0,
-    #             "y": 0,
-    #         }
-    #     },
-    #     "careful-carl": {
-    #         "search": {
-    #             "promptStrategy": "dummy",
-    #             "x": 0,
-    #             "y": 0,
-    #         }
-    #     }
-    # }
-    "codeCollections": [
-        # {"repoURL": f"file://{git_repo_root}/rw-public-codecollection", "branch": "main"},
-        # , "codeBundles": ["k8s-deployment-healthcheck"]
-        {"repoURL": f"file://{git_repo_root}/rw-cli-codecollection", "branch": "main"}
-    ]
+    # "codeCollections": [
+    #     {"repoURL": f"file://{git_repo_root}/rw-public-codecollection", "branch": "main"},
+    #     {"repoURL": f"file://{git_repo_root}/rw-cli-codecollection", "branch": "main"}
+    #     # , "codeBundles": ["k8s-namespace-healthcheck"]
+    #     # {
+    #     #     "repoURL": "https://github.com/runwhen-contrib/rw-cli-codecollection",
+    #     #     "branch": "main",
+    #     #     "codeBundles": ["k8s-namespace-healthcheck"],
+    #     # }
+    # ]
 }
-
 
 def read_file(file_path: str, mode="r") -> Union[str, bytes]:
     with open(file_path, mode) as f:


### PR DESCRIPTION
- This surfaced in the Kubernetes indexer where resources with the same name but in different clusters and/or namespaces were not being assigned to different resources, so only a single SLX would be generated.
- The solution was to have a qualified name for a resource that incorporates the parent cluster/namespace names and then use that as the key for indexing the resource instances in the resource type object.
- I also cleaned up some subtle ways where the registry data structures could get messed up if the same resources were scanned multiple times, e.g. if the kubeconfig has multiple contexts for the same cluster.
- I disabled the "resources" field for the namespace that collected all of the indexed resources for the namespace. It will take some more work to support that in a correct way. I don't think we're currently using it for anything, so I didn't want to waste cycles fixing up something that wasn't being used.