### PR TITLE
 CloudQuery-based indexer that supports Azure

### DIFF
--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -110,15 +110,19 @@ RUN wget -O /tmp/oc.tar.gz https://mirror.openshift.com/pub/openshift-v4/clients
     && tar -xzf /tmp/oc.tar.gz -C /usr/local/bin/ \
     && rm /tmp/oc.tar.gz
 
+# Download the cloudquery CLI
+RUN curl -L https://github.com/cloudquery/cloudquery/releases/download/cli-v3.19.4/cloudquery_linux_amd64 -o /usr/local/bin/cloudquery \
+    && chmod a+x /usr/local/bin/cloudquery
+
 # RunWhen customizations
 ADD . $RUNWHEN_HOME
 
 
 RUN mkdir $RUNWHEN_SHARED \
     && usermod -g 0 runwhen -G 0  \
-    &&  chown -R runwhen:0 $RUNWHEN_HOME $RUNWHEN_SHARED \ 
+    && chown -R runwhen:0 $RUNWHEN_HOME $RUNWHEN_SHARED \
     && chmod g=u /etc/passwd \
-    && chmod -R g+w ${RUNWHEN_HOME} ${RUNWHEN_SHARED}  
+    && chmod -R g+w ${RUNWHEN_HOME} ${RUNWHEN_SHARED}
 
 
 # Reverse Proxy Bits

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -87,6 +87,9 @@ ENV PATH "$PATH:/root/google-cloud-sdk/bin/"
 # FIXME - this crashed builds on nov 1 - skipping for now
 # RUN gcloud components install gke-gcloud-auth-plugin --quiet
 
+# Install Azure CLI
+RUN curl -sL https://aka.ms/InstallAzureCLIDeb | bash
+
 # Install lnav (https://github.com/tstack/lnav)
 ENV LNAV_VERSION 0.11.2
 RUN wget https://github.com/tstack/lnav/releases/download/v${LNAV_VERSION}/lnav-${LNAV_VERSION}-x86_64-linux-musl.zip\

--- a/src/cheat-sheet-docs/docs/overrides/main.html
+++ b/src/cheat-sheet-docs/docs/overrides/main.html
@@ -9,6 +9,16 @@
       </div>
     </div>
   {% endif %}
+    <div id="feedback-banner" class="fade-announcement">
+      <div class="fade-announcement-text">
+        📢   Your feedback is is valuable! Chat with us about improving RunWhen Local and <a href="https://github.com/orgs/runwhen-contrib/discussions/391" target="_blank"><b>receive a $100 Amazon Gift Card</b></a> in return! <button onclick="closeBanner()" style="color: white"> &nbsp &nbsp &nbsp &nbsp Hide Banner</button>
+        <script>
+          function closeBanner() {
+            document.getElementById('feedback-banner').style.display = 'none';
+          }
+        </script>
+      </div>
+    </div>
 {% endblock %}
 
 {% block content %}

--- a/src/component.py
+++ b/src/component.py
@@ -210,9 +210,10 @@ class Context:
         self.outputter = outputter
         self.properties = dict()
 
-    def get_setting(self, name: str) -> Any:
-        setting = all_settings.get(name)
-        return self.setting_values.get(name, setting.default_value)
+    def get_setting(self, setting: Union[str, Setting]) -> Any:
+        if isinstance(setting, str):
+            setting = all_settings.get(setting)
+        return self.setting_values.get(setting.name, setting.default_value)
 
     def write_file(self, path: str, data: AnyStr) -> None:
         self.outputter.write_file(path, data)

--- a/src/component.py
+++ b/src/component.py
@@ -242,7 +242,7 @@ def init_components():
     # be added here, which is less than ideal, although practically may not be
     # a huge deal.
     component_stages_init = (
-        (Stage.INDEXER, ["kubeapi"]),
+        (Stage.INDEXER, ["kubeapi", "cloudquery"]),
         (Stage.ENRICHER, ["runwhen_default_workspace", "generation_rules"]),
         (Stage.RENDERER, ["render_output_items", "dump_resources"])
     )

--- a/src/enrichers/azure.py
+++ b/src/enrichers/azure.py
@@ -1,0 +1,81 @@
+from typing import Any, Sequence
+
+from component import Context
+from resources import Resource, ResourceType, ResourceTypeSpec, Registry, REGISTRY_PROPERTY_NAME
+from .generation_rule_types import LevelOfDetail, PlatformHandler
+
+AZURE_PLATFORM = "azure"
+
+class AzurePlatformHandler(PlatformHandler):
+
+    def __init__(self):
+        super().__init__(AZURE_PLATFORM)
+
+    def process_resource_attributes(self,
+                                    resource_attributes: dict[str,Any],
+                                    resource_type_name: str,
+                                    registry: Registry) -> tuple[str, str]:
+        # FIXME: This assumes that all Azure tables have name and id fields/attributes.
+        # Seems likely, but not 100% sure this is a valid assumption.
+        name: str = resource_attributes['name']
+        qualified_name = name
+        if resource_type_name == "ResourceGroup":
+            # FIXME: Add level-of-detail logic here to set a 'lod' field based on a
+            # user-specified resourceGroupLODs configuration setting keyed by the
+            # resource group name, modeled on what we currently do with Kubernetes
+            # namespace resources. Or, alternatively, should possibly get rid of any
+            # LOD handling by the indexing logic.
+            # In any case, we want to skip the else logic here that tries to extract
+            # the parent resource group of the resource since that doesn't make sense
+            # for the resource group itself (unless Azure supports nested resource
+            # groups? but I don't think it does).
+            pass
+        else:
+            id: str = resource_attributes['id']
+            resource_groups_component_name = "resourceGroups/"
+            resource_group_start = id.find(resource_groups_component_name)
+            if resource_group_start >= 0:
+                resource_group_start += len(resource_groups_component_name)
+                resource_group_end = id.find('/', resource_group_start)
+                if resource_group_end > resource_group_start:
+                    resource_group_name = id[resource_group_start:resource_group_end]
+                    # Unfortunately the resource group name that's encoded in the id value has
+                    # been converted to all upper-case, so it's name doesn't match the key value
+                    # in the instances for the ResourceGroup resource type. So instead we need to
+                    # iterate over all the instances and do a case-insensitive comparison. Ugh!
+                    # Should think some more if there's a better / more efficient way to handle
+                    # this. AFAICT, there's no info in the resource attributes from which to
+                    # obtain the original, unconverted resource group, so instead would presumably
+                    # need to do some custom indexing of the resource groups where the key is
+                    # the upper-case version of the name and then use that for the duration of
+                    # the indexing process. We sort of do this already for the custom Kubernetes
+                    # index (where we maintain a dictionary of the discovered namespaces).
+                    # But I'm not sure in practice we're going to have cases where there are a
+                    # ton of resource groups (at least not right away) where this would be a
+                    # big scalability concern. Famous last words...
+                    # NB: Note that this logic assumes that the resource groups are indexed
+                    # first, so it should always be the first entry in the resource types
+                    # array for the CloudQuery platform spec.
+                    # FIXME: Ideally wouldn't hard-code/duplicate the "ResourceGroup" name here
+                    # but would instead define it once (not sure where makes the most sense?).
+                    resource_group_resource_type = registry.lookup_resource_type(AZURE_PLATFORM, "ResourceGroup")
+                    if resource_group_resource_type:
+                        for resource_group in resource_group_resource_type.instances.values():
+                            if resource_group.name.upper() == resource_group_name.upper():
+                                # Switch the resource group name back to the original name,
+                                # instead of the all-upper-case version.
+                                resource_group_name = resource_group.name
+                                resource_attributes['resource_group'] = resource_group
+                                break
+                    qualified_name = f"{resource_group_name}/{name}"
+
+        # Slightly kludgy to modify the input attributes and return them as the attributes,
+        # but this works with the existing CloudQuery indexer and is unlikely to change and
+        # save the cost of making a copy of the attributes.
+        del resource_attributes['name']
+        return name, qualified_name
+
+    # TODO: Override other methods (e.g. get_resource_property_values, add_template_variables)
+    # to handle Azure-specific logic. Probably, minimally, should handle Azure tags similar to the
+    # way we handle Kubernetes labels/annotations. Also, research what the Azure equivalent of a
+    # Kubernetes namespace is and support that as a built-in template variable.

--- a/src/enrichers/azure.py
+++ b/src/enrichers/azure.py
@@ -1,10 +1,22 @@
-from typing import Any, Sequence
+from typing import Any, Optional
+
+import json
 
 from component import Context
-from resources import Resource, ResourceType, ResourceTypeSpec, Registry, REGISTRY_PROPERTY_NAME
-from .generation_rule_types import LevelOfDetail, PlatformHandler
+from resources import Resource, Registry, REGISTRY_PROPERTY_NAME
+from .generation_rule_types import PlatformHandler, LevelOfDetail
 
 AZURE_PLATFORM = "azure"
+
+def get_resource_group(resource: Resource) -> Optional[Resource]:
+    # FIXME: Shouldn't use hard-coded string here
+    if resource.resource_type.name == "ResourceGroup":
+        return resource
+    try:
+        return getattr(resource, "resource_group")
+    except AttributeError:
+        return None
+
 
 class AzurePlatformHandler(PlatformHandler):
 
@@ -14,22 +26,41 @@ class AzurePlatformHandler(PlatformHandler):
     def process_resource_attributes(self,
                                     resource_attributes: dict[str,Any],
                                     resource_type_name: str,
-                                    registry: Registry) -> tuple[str, str]:
+                                    platform_config_data: dict[str,Any],
+                                    context: Context) -> tuple[str, str]:
         # FIXME: This assumes that all Azure tables have name and id fields/attributes.
         # Seems likely, but not 100% sure this is a valid assumption.
         name: str = resource_attributes['name']
         qualified_name = name
-        if resource_type_name == "ResourceGroup":
+        if resource_type_name == "resource_group":
             # FIXME: Add level-of-detail logic here to set a 'lod' field based on a
             # user-specified resourceGroupLODs configuration setting keyed by the
             # resource group name, modeled on what we currently do with Kubernetes
             # namespace resources. Or, alternatively, should possibly get rid of any
             # LOD handling by the indexing logic.
+            # Set the 'lod' (level-of-detail) resource attribute from the per-resource-group
+            # setting in the Azure cloud config or set to the default value if it's unspecified
+            # FIXME: It's a big kludgy to have the level of detail setting in the resource,
+            # since that's really a generation rules feature, not an indexing feature.
+            # Although we do currently use it in kubeapi to optimize the indexing to skip indexing
+            # namespaces whose level-of-detail is "none". But I still think it would be
+            # cleaner to not have any LOD setting logic in the indexers and just use it
+            # internally in the generation rules module. There could be some other mechanism
+            # to disable indexing for particular namespaces / resource groups in the indexers.
             # In any case, we want to skip the else logic here that tries to extract
             # the parent resource group of the resource since that doesn't make sense
             # for the resource group itself (unless Azure supports nested resource
             # groups? but I don't think it does).
-            pass
+            resource_group_level_of_detail_config = platform_config_data.get("resourceGroupLevelOfDetails", dict())
+            resource_group_lod_value = resource_group_level_of_detail_config.get(name)
+            # FIXME: Not great maintainance-wise to lookup setting values by the setting name here.
+            # Would be better to lookup by the actual Setting class singleton (which is not supported
+            # by the get_setting method). Unfortunately, currently, if we try to use the default LOD
+            # setting it leads to a module import circularity, so some cleanup/refactoring of
+            # where the settings are defined is needed to get that to work. So for the time being
+            # we still use the hard-coded name :-(
+            resource_attributes['lod'] = LevelOfDetail.construct_from_config(resource_group_lod_value) \
+                if resource_group_lod_value is not None else context.get_setting("DEFAULT_LOD")
         else:
             id: str = resource_attributes['id']
             resource_groups_component_name = "resourceGroups/"
@@ -56,9 +87,10 @@ class AzurePlatformHandler(PlatformHandler):
                     # NB: Note that this logic assumes that the resource groups are indexed
                     # first, so it should always be the first entry in the resource types
                     # array for the CloudQuery platform spec.
-                    # FIXME: Ideally wouldn't hard-code/duplicate the "ResourceGroup" name here
+                    # FIXME: Ideally wouldn't hard-code/duplicate the "resource_group" name here
                     # but would instead define it once (not sure where makes the most sense?).
-                    resource_group_resource_type = registry.lookup_resource_type(AZURE_PLATFORM, "ResourceGroup")
+                    registry: Registry = context.get_property(REGISTRY_PROPERTY_NAME)
+                    resource_group_resource_type = registry.lookup_resource_type(AZURE_PLATFORM, "resource_group")
                     if resource_group_resource_type:
                         for resource_group in resource_group_resource_type.instances.values():
                             if resource_group.name.upper() == resource_group_name.upper():
@@ -72,10 +104,73 @@ class AzurePlatformHandler(PlatformHandler):
         # Slightly kludgy to modify the input attributes and return them as the attributes,
         # but this works with the existing CloudQuery indexer and is unlikely to change and
         # save the cost of making a copy of the attributes.
+        if "instance_view" in resource_attributes:
+            # The instance_view attribute corresponds most closely to the raw resource data
+            # that a gen rule author might want to probe. We rename it to "resource" to be
+            # consistent across different indexers and that's what the Kubernetes indexer uses.
+            # The content of that field is JSON text, so we deserialize to Python objects,
+            # so that the elements can be access from match predicates and/or template variables.
+            instance_view_str = resource_attributes['instance_view']
+            instance_view_data = json.loads(instance_view_str)
+            resource_attributes['resource'] = instance_view_data
+            del resource_attributes['instance_view']
+
+        # Similarly the tags data is JSON text that we deserialize
+        # FIXME: Should possibly just have code at the top-level CloudQuery indexer level
+        # that checks for JSON fields (or is perhaps configured in the platform spec) and
+        # automatically deserializes them?
+        # At least in the Azure case, there are a bunch of fields that are JSON that ideally
+        # should be converted.
+        tags_str = resource_attributes.get('tags')
+        if tags_str is not None:
+            tags_data = json.loads(tags_str)
+            resource_attributes['tags'] = tags_data
+
         del resource_attributes['name']
         return name, qualified_name
 
     # TODO: Override other methods (e.g. get_resource_property_values, add_template_variables)
     # to handle Azure-specific logic. Probably, minimally, should handle Azure tags similar to the
-    # way we handle Kubernetes labels/annotations. Also, research what the Azure equivalent of a
-    # Kubernetes namespace is and support that as a built-in template variable.
+    # way we handle Kubernetes labels/annotations.
+
+    def get_level_of_detail(self, resource: Resource) -> Optional[LevelOfDetail]:
+        resource_group = get_resource_group(resource)
+        if not resource_group:
+            return None
+        level_of_detail = getattr(resource_group, 'lod')
+        return level_of_detail
+
+    @staticmethod
+    def get_common_resource_property_values(resource: Resource, qualifier_name: str) -> Optional[str]:
+        if qualifier_name == "resource_group":
+            return get_resource_group(resource).name
+        else:
+            # FIXME: Should we treat this as an error, i.e. raise Exception?
+            return None
+
+    def get_resource_qualifier_value(self, resource: Resource, qualifier_name: str) -> Optional[str]:
+        return self.get_common_resource_property_values(resource, qualifier_name)
+
+    def get_resource_property_values(self, resource: Resource, property_name: str) -> Optional[list[Any]]:
+        property_name = property_name.lower()
+        if property_name == "tags":
+            return list(resource.tags.keys()) + list(resource.tags.values())
+        elif property_name == "tag-keys":
+            return list(resource.tags.keys())
+        elif property_name == "tag-values":
+            return list(resource.tags.values())
+        else:
+            # Note, the property value may be a path within the
+            return None
+
+    def get_standard_template_variables(self, resource: Resource) -> dict[str, Any]:
+        template_variables = dict()
+        resource_group = get_resource_group(resource)
+        if resource_group:
+            template_variables['resource_group'] = resource_group
+        return template_variables
+
+    def resolve_template_variable_value(self, resource: Resource, variable_name: str) -> Optional[Any]:
+        return self.get_common_resource_property_values(resource, variable_name)
+
+

--- a/src/enrichers/azure.py
+++ b/src/enrichers/azure.py
@@ -108,23 +108,7 @@ class AzurePlatformHandler(PlatformHandler):
             # The instance_view attribute corresponds most closely to the raw resource data
             # that a gen rule author might want to probe. We rename it to "resource" to be
             # consistent across different indexers and that's what the Kubernetes indexer uses.
-            # The content of that field is JSON text, so we deserialize to Python objects,
-            # so that the elements can be access from match predicates and/or template variables.
-            instance_view_str = resource_attributes['instance_view']
-            instance_view_data = json.loads(instance_view_str)
-            resource_attributes['resource'] = instance_view_data
-            del resource_attributes['instance_view']
-
-        # Similarly the tags data is JSON text that we deserialize
-        # FIXME: Should possibly just have code at the top-level CloudQuery indexer level
-        # that checks for JSON fields (or is perhaps configured in the platform spec) and
-        # automatically deserializes them?
-        # At least in the Azure case, there are a bunch of fields that are JSON that ideally
-        # should be converted.
-        tags_str = resource_attributes.get('tags')
-        if tags_str is not None:
-            tags_data = json.loads(tags_str)
-            resource_attributes['tags'] = tags_data
+            resource_attributes['resource'] = resource_attributes.pop('instance_view')
 
         del resource_attributes['name']
         return name, qualified_name

--- a/src/enrichers/generation_rule_types.py
+++ b/src/enrichers/generation_rule_types.py
@@ -7,6 +7,9 @@ from resources import Resource, ResourceTypeSpec, Registry, REGISTRY_PROPERTY_NA
 
 PLATFORM_HANDLERS_PROPERTY_NAME = "platform-handlers"
 
+# The value of this is a dict whose key is platform names and value is a set of resource type names
+RESOURCE_TYPE_SPECS_PROPERTY = "resource-type-specs"
+
 class LevelOfDetail(Enum):
     """
     A setting that is used to control how much information to generate.
@@ -46,7 +49,8 @@ class PlatformHandler:
     def process_resource_attributes(self,
                                     resource_attributes: dict[str,Any],
                                     resource_type_name: str,
-                                    registry: Registry) -> tuple[str, str]:
+                                    platform_config_data: Optional[dict[str,Any]],
+                                    context: Context) -> tuple[str, str]:
         """
         This is primarily for use by the CloudQuery indexer to handle the processing of the raw
         resource attributes obtained from CloudQuery to the data that's used to create the resource
@@ -70,7 +74,7 @@ class PlatformHandler:
         resource_type = registry.lookup_resource_type(self.name, resource_type_spec.resource_type_name)
         return resource_type.instances.values() if resource_type else list()
 
-    def get_level_of_detail(self, resource: Resource):
+    def get_level_of_detail(self, resource: Resource) -> LevelOfDetail:
         """
         Return the level of detail associated with the specified resource. Platforms
         override this to implement whatever platform-specific logic they support, if any.
@@ -79,7 +83,7 @@ class PlatformHandler:
         """
         return LevelOfDetail.DETAILED
 
-    def get_resource_match_property_value(self, resource: Resource, property_name: str) -> Optional[str]:
+    def get_resource_qualifier_value(self, resource: Resource, qualfifier_name: str) -> Optional[str]:
         return None
 
     def get_resource_property_values(self, resource: Resource, property_name: str) -> Optional[list[Any]]:
@@ -94,7 +98,7 @@ class PlatformHandler:
         """
         return None
 
-    def add_template_variables(self, resource: Resource, template_variables: dict[str, Any]) -> None:
+    def get_standard_template_variables(self, resource: Resource) -> dict[str, Any]:
         """
         Add any platform-specific template variables to the dictionary that will be passed to jinja.
         Typically, this will be attributes derived from the resource that was matched (e.g. for
@@ -103,16 +107,16 @@ class PlatformHandler:
         Adding these standard/built-in template variables simplifies things for template authors,
         so they don't need to explicitly declare these common variables in generation rules.
         """
-        pass
+        return dict()
 
-    def resolve_template_variable_value(self, resource: Resource, template_value_str: str) -> Optional[Any]:
+    def resolve_template_variable_value(self, resource: Resource, variable_name: str) -> Optional[Any]:
         """
         Resolve a platform-specific custom/special value for a template variable.
         For example, the Kubernetes platform supports special values like "namespace"
         and "cluster" for the value derived from the matching resource, although this
         is sort of obsolete/unncessary at this point (see FIXME not below).
 
-        FIXME: Not sure this is really needed anymore. In the early version of the WB the
+        FIXME: I'm not sure this is really needed anymore. In the early version of the WB the
         idea was that all of the template variables used in the templates for a gen rule
         needed to be specified explicitly in the gen rule. But that turned out to be
         annoying for the gen rule developer, since there were a few common ones that were

--- a/src/enrichers/generation_rule_types.py
+++ b/src/enrichers/generation_rule_types.py
@@ -1,10 +1,9 @@
-from abc import ABC, abstractmethod
 from enum import Enum
 from typing import Any, Optional, Sequence, Union
 
 from component import Context
 from exceptions import WorkspaceBuilderException
-from resources import Resource, ResourceTypeSpec
+from resources import Resource, ResourceTypeSpec, Registry, REGISTRY_PROPERTY_NAME
 
 PLATFORM_HANDLERS_PROPERTY_NAME = "platform-handlers"
 
@@ -34,7 +33,7 @@ class LevelOfDetail(Enum):
         raise WorkspaceBuilderException(f"Invalid level of detail value: {config}")
 
 
-class PlatformHandler: #(ABC):
+class PlatformHandler:
 
     name: str
 
@@ -44,20 +43,40 @@ class PlatformHandler: #(ABC):
     def construct_resource_type_spec(self, config: Union[str, dict[str, Any]]) -> ResourceTypeSpec:
         return ResourceTypeSpec.construct_from_config(config, self.name)
 
-    # @abstractmethod
+    def process_resource_attributes(self,
+                                    resource_attributes: dict[str,Any],
+                                    resource_type_name: str,
+                                    registry: Registry) -> tuple[str, str]:
+        """
+        This is primarily for use by the CloudQuery indexer to handle the processing of the raw
+        resource attributes obtained from CloudQuery to the data that's used to create the resource
+        in the registry. The return value is a tuple of:
+            (<resource-name>, <qualified-resource-name>, <resource-attributes>)
+        """
+        name = resource_attributes['name']
+        del resource_attributes['name']
+        return name, name
+
     def get_resources(self, resource_type_spec: ResourceTypeSpec, context: Context) -> Sequence[Resource]:
         """
         Implement any platform-specific logic to look up the resources of the specified
         type. In most cases this will just be looking up the resource type in the registry,
+        and returning the instances (i.e. the default/generic implementation below),
         but if the resource type name encodes other information (e.g. Kubernetes custom
         resources), then this is where that info would be parsed and translated into lookup
         calls in the registry.
         """
-        # This method is required to be overridden by the platform subclasses, so raise an
-        # exception if they haven't.
-        raise WorkspaceBuilderException(f"PlatformHandler.get_resources not implemented by subclass: {type(self)}")
+        registry: Registry = context.get_property(REGISTRY_PROPERTY_NAME)
+        resource_type = registry.lookup_resource_type(self.name, resource_type_spec.resource_type_name)
+        return resource_type.instances.values() if resource_type else list()
 
     def get_level_of_detail(self, resource: Resource):
+        """
+        Return the level of detail associated with the specified resource. Platforms
+        override this to implement whatever platform-specific logic they support, if any.
+        The typical model is to provide level-of-detail customization based on whatever
+        resource scoping is supported by the platform, e.g. Kubernetes namespaces.
+        """
         return LevelOfDetail.DETAILED
 
     def get_resource_match_property_value(self, resource: Resource, property_name: str) -> Optional[str]:

--- a/src/enrichers/generation_rules.py
+++ b/src/enrichers/generation_rules.py
@@ -12,6 +12,7 @@ from indexers.kubetypes import get_namespace, get_cluster
 from name_utils import shorten_name, make_qualified_slx_name, make_slx_name
 from .generation_rule_types import PLATFORM_HANDLERS_PROPERTY_NAME, PlatformHandler, LevelOfDetail
 from .kubernetes import KubernetesPlatformHandler
+from .azure import AzurePlatformHandler, AZURE_PLATFORM
 from renderers.render_output_items import OUTPUT_ITEMS_PROPERTY
 from renderers.render_output_items import OutputItem as RendererOutputItem
 from resources import (
@@ -792,7 +793,8 @@ def load(context: Context) -> None:
     # on all the platform handlers.
     # Could perhaps do some sort of dynamic discovery/loading/registration of all the platform handlers?
     platform_handlers = {
-        KUBERNETES_PLATFORM: KubernetesPlatformHandler(KUBERNETES_PLATFORM),
+        KUBERNETES_PLATFORM: KubernetesPlatformHandler(),
+        AZURE_PLATFORM: AzurePlatformHandler()
     }
     context.set_property(PLATFORM_HANDLERS_PROPERTY_NAME, platform_handlers)
     request_code_collections = context.get_setting("CODE_COLLECTIONS")

--- a/src/enrichers/generation_rules.py
+++ b/src/enrichers/generation_rules.py
@@ -443,8 +443,8 @@ class GenerationRule:
                 # to the new format then falls through to the rest of the code that checks
                 # for other predicate types, and eventually handles the "variables" match
                 # predicate type.
-                resourceType = match_predicate_config.get("resourceType")
-                if resourceType and resourceType.lower() == 'variables':
+                resource_type = match_predicate_config.get("resourceType")
+                if resource_type and resource_type.lower() == 'variables':
                     properties = match_predicate_config.get("properties")
                     if properties and isinstance(properties, list) and len(properties) == 1:
                         path = properties[0]

--- a/src/enrichers/generation_rules.py
+++ b/src/enrichers/generation_rules.py
@@ -8,9 +8,14 @@ import yaml
 from component import Context, Setting, SettingDependency, WORKSPACE_NAME_SETTING, WORKSPACE_OUTPUT_PATH_SETTING
 from exceptions import WorkspaceBuilderException
 from indexers.kubetypes import KUBERNETES_PLATFORM
-from indexers.kubetypes import get_namespace, get_cluster
 from name_utils import shorten_name, make_qualified_slx_name, make_slx_name
-from .generation_rule_types import PLATFORM_HANDLERS_PROPERTY_NAME, PlatformHandler, LevelOfDetail
+from .generation_rule_types import (
+    PLATFORM_HANDLERS_PROPERTY_NAME,
+    PlatformHandler,
+    LevelOfDetail,
+    RESOURCE_TYPE_SPECS_PROPERTY
+)
+
 from .kubernetes import KubernetesPlatformHandler
 from .azure import AzurePlatformHandler, AZURE_PLATFORM
 from renderers.render_output_items import OUTPUT_ITEMS_PROPERTY
@@ -97,8 +102,6 @@ GROUPS_PROPERTY = "groups"
 SLXS_PROPERTY = "SLXS"
 SLX_RELATIONSHIPS_PROPERTY = "slx-relationships"
 GENERATION_RULES_PROPERTY = "generation-rules"
-# The value of this is a dict whose key is platform names and value is a set of resource type names
-RESOURCE_TYPE_SPECS_PROPERTY = "resource-type-specs"
 # This is the dict key name for specifying the platform name in gen rules
 # and the associated resource types.
 PLATFORM_NAME_KEY_NAME = "platform"
@@ -525,7 +528,7 @@ class GenerationRuleInfo:
 
 
 def get_template_variables(output_item: OutputItem,
-                           resource: Any,
+                           resource: Resource,
                            base_template_variables: dict[str, Any],
                            generation_rule_info: GenerationRuleInfo,
                            context: Context) -> dict[str, Any]:
@@ -553,7 +556,8 @@ def get_template_variables(output_item: OutputItem,
         platform_name = resource.resource_type.platform.name
         platform_handlers: dict[str, PlatformHandler] = context.get_property(PLATFORM_HANDLERS_PROPERTY_NAME)
         platform_handler = platform_handlers[platform_name]
-        platform_handler.add_template_variables(resource, template_variables)
+        standard_template_variables = platform_handler.get_standard_template_variables(resource)
+        template_variables.update(standard_template_variables)
     else:
         platform_handler = None
 
@@ -717,9 +721,6 @@ def generate_slx_output_items(slx_info: SLXInfo,
     :return:
     """
     resource = slx_info.resource
-    # FIXME: Kubernetes dependency
-    namespace = get_namespace(resource)
-    cluster = get_cluster(resource)
     generation_rule_info = slx_info.generation_rule_info
 
     slx_base_template_variables = base_template_variables.copy()
@@ -744,10 +745,14 @@ def generate_slx_output_items(slx_info: SLXInfo,
         "resource": resource,
         "slx-info": slx_info
     }
-    if namespace:
-        customization_variables['namespace'] = namespace
-    if cluster:
-        customization_variables['cluster'] = cluster
+
+    # FIXME: This logic to set the standard template variables is a bit klunky and uses
+    # duplicated code. Should clean up / refactor.
+    platform_name = resource.resource_type.platform.name
+    platform_handlers: dict[str, PlatformHandler] = context.get_property(PLATFORM_HANDLERS_PROPERTY_NAME)
+    platform_handler = platform_handlers[platform_name]
+    standard_template_variables = platform_handler.get_standard_template_variables(resource)
+    customization_variables.update(standard_template_variables)
     group_name_template = map_customization_rules.match_group_rules(slx_info)
     if group_name_template:
         group_name = render_template_string(group_name_template, customization_variables)
@@ -897,7 +902,6 @@ def enrich(context: Context) -> None:
         'shorten_name': shorten_name,
         'make_slx_name': make_slx_name,
         'make_slx_directory_name': make_qualified_slx_name,
-        'resources': dict(),
     }
 
     generation_rule_infos: list[GenerationRuleInfo] = context.get_property(GENERATION_RULES_PROPERTY)
@@ -905,12 +909,12 @@ def enrich(context: Context) -> None:
         generation_rule = generation_rule_info.generation_rule
         for resource_type_spec in generation_rule.resource_type_specs:
             resources = get_resources(context, resource_type_spec)
+            base_template_variables['resources'] = dict()
             for resource in resources:
                 platform_name = resource.resource_type.platform.name
                 platform_handler = platform_handlers[platform_name]
                 level_of_detail = platform_handler.get_level_of_detail(resource)
                 resource_type_name = resource_type_spec.get_resource_type_name()
-                base_template_variables['resources'][resource_type_name] = resource
                 generation_rule_match_info = GenerationRuleMatchInfo(resource, base_template_variables, context)
                 matches = generation_rule.match_predicate.matches(generation_rule_match_info)
                 if matches:
@@ -918,6 +922,11 @@ def enrich(context: Context) -> None:
                     # detection/resolution for these. I actually don't think we're using these for
                     # anything currently, so we might want to take out support for this to simplify
                     # things a bit.
+                    #
+                    # standard_template_variables = platform_handler.get_standard_template_variables(resource)
+                    # resource_template_variables = base_template_variables.copy()
+                    # resource_template_variables.update(standard_template_variables)
+                    base_template_variables['resources'][resource_type_name] = resource
                     for output_item in generation_rule.output_items:
                         if should_emit_output_item(output_item, level_of_detail):
                             generate_output_item(generation_rule_info,

--- a/src/enrichers/kubernetes.py
+++ b/src/enrichers/kubernetes.py
@@ -15,6 +15,9 @@ from .generation_rule_types import LevelOfDetail, PlatformHandler
 
 class KubernetesPlatformHandler(PlatformHandler):
 
+    def __init__(self):
+        super().__init__(KUBERNETES_PLATFORM)
+
     def construct_resource_type_spec(self, config: Union[str, dict[str, Any]]) -> KubernetesResourceTypeSpec:
         return KubernetesResourceTypeSpec.construct_from_config(config)
 

--- a/src/enrichers/map_customization_rules.py
+++ b/src/enrichers/map_customization_rules.py
@@ -23,7 +23,7 @@ def get_qualifier_value(qualifier: str, resource: Resource, context: Context) ->
     platform_handlers: dict[str, PlatformHandler] = context.get_property(PLATFORM_HANDLERS_PROPERTY_NAME)
     platform_name = resource.resource_type.platform.name
     platform_handler = platform_handlers[platform_name]
-    value = platform_handler.get_resource_match_property_value(resource, qualifier)
+    value = platform_handler.get_resource_qualifier_value(resource, qualifier)
     if value is None:
         raise WorkspaceBuilderException(f'Unresolved qualifier value for SLX name: "{qualifier}"')
     return value

--- a/src/indexers/cloudquery.py
+++ b/src/indexers/cloudquery.py
@@ -128,7 +128,7 @@ def init_cloudquery_config(cloud_config_data: dict[str, Any],
                 if cq_resource_type_spec.resource_type_name == resource_type_name:
                     break
             else:
-                cq_resource_type_spec = CloudQueryResourceTypeSpec(resource_type_name, resource_type_name)
+                cq_resource_type_spec = CloudQueryResourceTypeSpec(resource_type_name, resource_type_name, False)
             if not cq_resource_type_spec.mandatory:
                 cq_resource_type_specs.append(cq_resource_type_spec)
                 tables.append(cq_resource_type_spec.cloudquery_table_name)

--- a/src/indexers/cloudquery.py
+++ b/src/indexers/cloudquery.py
@@ -1,0 +1,190 @@
+from copy import deepcopy
+from dataclasses import dataclass
+import logging
+import os
+import sqlite3
+import tempfile
+from template import render_template_file
+from typing import Any
+import subprocess
+
+# import models
+from component import Setting, SettingDependency, Context
+from exceptions import WorkspaceBuilderException
+from enrichers.generation_rule_types import PlatformHandler, PLATFORM_HANDLERS_PROPERTY_NAME
+from resources import Registry, REGISTRY_PROPERTY_NAME
+from utils import read_file, write_file
+
+logger = logging.getLogger(__name__)
+
+DOCUMENTATION = "Index resources using CloudQuery"
+
+CLOUD_CONFIG_SETTING = Setting("CLOUD_CONFIG",
+                               "cloudConfig",
+                               Setting.Type.DICT,
+                               "Configuration/credential info for the cloud input sources",
+                               dict())
+
+SETTINGS = (
+    SettingDependency(CLOUD_CONFIG_SETTING, False),
+)
+
+@dataclass
+class CloudQueryResourceTypeSpec:
+    # The name of the resource type in the resource registry
+    resource_type_name: str
+    # The name of the table in the CloudQuery database
+    cloudquery_table_name: str
+
+
+@dataclass
+class CloudQueryPlatformSpec:
+    name: str
+    config_file_name: str
+    # The path/name of the template file used to generate the config file for this platform
+    config_template_name: str
+    environment_variables: dict[str, str]
+    # The info for the resource types supported for this platform
+    resource_type_specs: list[CloudQueryResourceTypeSpec]
+
+
+platform_specs = [
+    CloudQueryPlatformSpec("azure",
+                           config_file_name="azure.yaml",
+                           config_template_name="azure-config.yaml",
+                           environment_variables={
+                               "AZURE_SUBSCRIPTION_ID": "subscriptionId",
+                               "AZURE_TENANT_ID": "tenantId",
+                               "AZURE_CLIENT_ID": "clientId",
+                               "AZURE_CLIENT_SECRET": "clientSecret"
+                           },
+                           resource_type_specs=[
+                               # IMPORTANT!!! The ResourceGroup resource type must be the first entry here so that
+                               # they're all created before processing the other resource types, which
+                               # set a resource_group field that points to their parent resource group instance.
+                               CloudQueryResourceTypeSpec(resource_type_name="ResourceGroup",
+                                                          cloudquery_table_name="azure_resources_resource_groups"),
+                               CloudQueryResourceTypeSpec(resource_type_name="ComputeVirtualMachine",
+                                                          cloudquery_table_name="azure_compute_virtual_machines"),
+                           ])
+]
+
+def init_cloudquery_config(cloud_config_data: dict[str, Any],
+                           cloud_config_dir: str,
+                           db_file_path: str) -> dict[str, str]:
+    cq_process_environment_vars = dict()
+
+    # Set up a template loader func to load from the CloudQuery template dir
+    templates_dir = "indexers/cloudquery_templates"
+    template_loader_func = lambda name: read_file(os.path.join(templates_dir, name))
+
+    # Create the sqlite destination config file
+    sqlite_config_path = os.path.join(cloud_config_dir, "sqlite.yaml")
+    template_variables = {"database_path": db_file_path}
+    sqlite_config_text = render_template_file("sqlite-config.yaml", template_variables, template_loader_func)
+    write_file(sqlite_config_path, sqlite_config_text)
+
+    for platform_spec in platform_specs:
+        platform_name = platform_spec.name
+        platform_config_data = cloud_config_data.get(platform_name)
+        if platform_config_data is None:
+            continue
+
+        # Set up any environment variables for the platform
+        for env_var_name, config_name in platform_spec.environment_variables.items():
+            env_var_value = platform_config_data.get(config_name)
+            if env_var_value is not None:
+                cq_process_environment_vars[env_var_name] = env_var_value
+
+        # Start the template variables from the platform config dict. That way the template
+        # for a platform can support platform-specific configuration options without having
+        # to hard-code anything in the platform spec.
+        # NB: We do the deep copy just to be safe, since the root_config_data argument is
+        # owned by the caller, so we shouldn't modify it.
+        template_variables = deepcopy(platform_config_data)
+        template_variables["destination_plugin_name"] = "sqlite"
+        tables = [resource_type_spec.cloudquery_table_name for resource_type_spec in platform_spec.resource_type_specs]
+        template_variables["tables"] = tables
+        config_file_path = os.path.join(cloud_config_dir, platform_spec.config_file_name)
+        config_text = render_template_file(platform_spec.config_template_name, template_variables, template_loader_func)
+        write_file(config_file_path, config_text)
+
+    return cq_process_environment_vars
+
+def index(context: Context):
+    logger.debug("CloudQuery indexing beginning")
+
+    cloud_config_data = context.get_setting("CLOUD_CONFIG")
+    if not cloud_config_data:
+        return
+
+    platform_handlers: dict[str, PlatformHandler] = context.get_property(PLATFORM_HANDLERS_PROPERTY_NAME)
+
+    registry: Registry = context.get_property(REGISTRY_PROPERTY_NAME)
+    with tempfile.TemporaryDirectory() as cq_temp_dir:
+        # Create a config directory in the temp directory where we'll put all the CloudQuery config files
+        cloudquery_config_dir = os.path.join(cq_temp_dir, "config")
+        os.makedirs(cloudquery_config_dir)
+
+        # Create the CloudQuery source/destination config files
+        sqlite_database_file_path = os.path.join(cq_temp_dir, "db.sql")
+        env_vars = init_cloudquery_config(cloud_config_data, cloudquery_config_dir, sqlite_database_file_path)
+
+        # Invoke CloudQuery to scan for resources from all the configured platforms
+        path = os.getenv("PATH")
+        env_vars["PATH"] = path
+        try:
+            process_info = subprocess.run(["cloudquery", "sync", f"{cloudquery_config_dir}"], capture_output=True, env=env_vars)
+        except Exception as e:
+            # This exception handling is just to aid in debugging/development.
+            # Can remove it once things are more settled.
+            raise e
+
+        # Convert the tables from the sqlite DB to resources in the resource registry
+        sql_connection = sqlite3.connect(sqlite_database_file_path)
+        cursor = sql_connection.cursor()
+        for platform_spec in platform_specs:
+            platform_handler = platform_handlers[platform_spec.name]
+            for resource_type_spec in platform_spec.resource_type_specs:
+                # table_name = f"{platform_spec.name}_{resource_type_spec.cloudquery_table_name}"
+                table_name = resource_type_spec.cloudquery_table_name
+                # Extract the fields we need from the sqlite table.
+                # Would simplify the spec for the platform and I don't think it's really buying us that
+                # much in terms of performance/efficiency to only fetch a subset, since we'll probably
+                # always want to get the full instance_view of the resource, which is likely the
+                # biggest field. So could just do a SELECT * and then use the description field in the
+                # response to get the field names.
+                try:
+                    response = cursor.execute(f"SELECT * FROM {table_name}")
+                    # response = cursor.execute(f"SELECT {joined_cloudquery_field_names} FROM {table_name}")
+                except sqlite3.OperationalError as e:
+                    # If no instances of the table were discovered, then the table will not be defined in the
+                    # database, and the SQL execution raises an OperationalError. We don't want to treat
+                    # that as an error, so we just continue in that case.
+                    # FIXME: Are there are other errors that could occur here that we should handle differently?
+                    # Should probably verify that the exception is due to the table not being found.
+                    # Seems like the only way you can do that is to parse the error message, which is sort of ugly.
+                    continue
+                table_rows = response.fetchall()
+                field_descriptions = response.description
+                # resource_name = None
+                for table_row in table_rows:
+                    # Combine the field descriptions and the row values to set up the resource attributes.
+                    resource_attributes = dict()
+                    for i in range(len(field_descriptions)):
+                        attribute_name = field_descriptions[i][0]
+                        attribute_value = table_row[i]
+                        resource_attributes[attribute_name] = attribute_value
+                    # Call the platform handler to extract the name and qualified name from the
+                    # resource attributes and possibly make alterations to the attributes.
+                    resource_name, qualified_resource_name = \
+                        platform_handler.process_resource_attributes(resource_attributes,
+                                                                     resource_type_spec.resource_type_name,
+                                                                     registry)
+                    registry.add_resource(platform_spec.name,
+                                          resource_type_spec.resource_type_name,
+                                          resource_name,
+                                          qualified_resource_name,
+                                          resource_attributes)
+
+        logger.debug("CloudQuery indexing ending")

--- a/src/indexers/cloudquery.py
+++ b/src/indexers/cloudquery.py
@@ -7,10 +7,10 @@ import tempfile
 from template import render_template_file
 from typing import Any
 import subprocess
+import yaml
 
 # import models
 from component import Setting, SettingDependency, Context
-from exceptions import WorkspaceBuilderException
 from enrichers.generation_rule_types import (
     PlatformHandler,
     PLATFORM_HANDLERS_PROPERTY_NAME,
@@ -160,88 +160,100 @@ def init_cloudquery_config(cloud_config_data: dict[str, Any],
     return cq_process_environment_vars, platform_tables
 
 def index(context: Context):
-    logger.debug("CloudQuery indexing beginning")
+    logger.info("Starting CloudQuery indexing")
 
     cloud_config_data = context.get_setting("CLOUD_CONFIG")
-    if not cloud_config_data:
-        return
+    if cloud_config_data:
+        platform_handlers: dict[str, PlatformHandler] = context.get_property(PLATFORM_HANDLERS_PROPERTY_NAME)
+        accessed_resource_type_specs: dict[str, list[ResourceTypeSpec]] = context.get_property(RESOURCE_TYPE_SPECS_PROPERTY)
 
-    platform_handlers: dict[str, PlatformHandler] = context.get_property(PLATFORM_HANDLERS_PROPERTY_NAME)
-    accessed_resource_type_specs: dict[str, list[ResourceTypeSpec]] = context.get_property(RESOURCE_TYPE_SPECS_PROPERTY)
+        registry: Registry = context.get_property(REGISTRY_PROPERTY_NAME)
+        with tempfile.TemporaryDirectory() as cq_temp_dir:
+            # Create a config directory in the temp directory where we'll put all the CloudQuery config files
+            cq_config_dir = os.path.join(cq_temp_dir, "config")
+            os.makedirs(cq_config_dir)
 
-    registry: Registry = context.get_property(REGISTRY_PROPERTY_NAME)
-    with tempfile.TemporaryDirectory() as cq_temp_dir:
-        # Create a config directory in the temp directory where we'll put all the CloudQuery config files
-        cq_config_dir = os.path.join(cq_temp_dir, "config")
-        os.makedirs(cq_config_dir)
+            # Create the CloudQuery source/destination config files
+            sqlite_database_file_path = os.path.join(cq_temp_dir, "db.sql")
+            env_vars, cq_platform_infos = init_cloudquery_config(cloud_config_data,
+                                                                 cq_config_dir,
+                                                                 sqlite_database_file_path,
+                                                                 accessed_resource_type_specs)
 
-        # Create the CloudQuery source/destination config files
-        sqlite_database_file_path = os.path.join(cq_temp_dir, "db.sql")
-        env_vars, cq_platform_infos = init_cloudquery_config(cloud_config_data,
-                                                             cq_config_dir,
-                                                             sqlite_database_file_path,
-                                                             accessed_resource_type_specs)
+            if len(cq_platform_infos) > 0:
+                # Invoke CloudQuery to scan for resources from all the configured platforms
+                path = os.getenv("PATH")
+                env_vars["PATH"] = path
+                try:
+                    process_info = subprocess.run(["cloudquery", "sync", f"{cq_config_dir}"],
+                                                  capture_output=True,
+                                                  env=env_vars)
+                except Exception as e:
+                    # This exception handling is just to aid in debugging/development.
+                    # Can remove it once things are more settled.
+                    raise e
 
-        if len(cq_platform_infos) > 0:
-            # Invoke CloudQuery to scan for resources from all the configured platforms
-            path = os.getenv("PATH")
-            env_vars["PATH"] = path
-            try:
-                process_info = subprocess.run(["cloudquery", "sync", f"{cq_config_dir}"],
-                                              capture_output=True,
-                                              env=env_vars)
-            except Exception as e:
-                # This exception handling is just to aid in debugging/development.
-                # Can remove it once things are more settled.
-                raise e
+                # Convert the tables from the sqlite DB to resources in the resource registry
+                sql_connection = sqlite3.connect(sqlite_database_file_path)
+                cursor = sql_connection.cursor()
+                for cq_platform_spec, cq_resource_type_specs in cq_platform_infos:
+                    platform_config_data = cloud_config_data.get(cq_platform_spec.name, dict())
+                    platform_handler = platform_handlers[cq_platform_spec.name]
+                    for cq_resource_type_spec in cq_resource_type_specs:
+                        # table_name = f"{platform_spec.name}_{resource_type_spec.cloudquery_table_name}"
+                        # table_name = resource_type_spec.cloudquery_table_name
+                        # Extract the fields we need from the sqlite table.
+                        # Would simplify the spec for the platform and I don't think it's really buying us that
+                        # much in terms of performance/efficiency to only fetch a subset, since we'll probably
+                        # always want to get the full instance_view of the resource, which is likely the
+                        # biggest field. So could just do a SELECT * and then use the description field in the
+                        # response to get the field names.
+                        try:
+                            response = cursor.execute(f"SELECT * FROM {cq_resource_type_spec.cloudquery_table_name}")
+                            # response = cursor.execute(f"SELECT {joined_cloudquery_field_names} FROM {table_name}")
+                        except sqlite3.OperationalError as e:
+                            # If no instances of the table were discovered, then the table will not be defined in the
+                            # database, and the SQL execution raises an OperationalError. We don't want to treat
+                            # that as an error, so we just continue in that case.
+                            # FIXME: Are there are other errors that could occur here that we should handle differently?
+                            # Should probably verify that the exception is due to the table not being found.
+                            # Seems like the only way you can do that is to parse the error message, which is sort of ugly.
+                            continue
+                        table_rows = response.fetchall()
+                        field_descriptions = response.description
+                        # resource_name = None
+                        for table_row in table_rows:
+                            # Combine the field descriptions and the row values to set up the resource attributes.
+                            resource_attributes = dict()
+                            for i in range(len(field_descriptions)):
+                                attribute_name = field_descriptions[i][0]
+                                attribute_value = table_row[i]
+                                # CloudQuery encodes a number of attributes as JSON text, so we try
+                                # to convert to Python data, so that the data can be accessed/navigated
+                                # by match predicates and template variable expressions. If the data,
+                                # is not JSON, then an exception will be raised and ignored and we just
+                                # use the original value.
+                                # FIXME: I think this should do the right thing for all expected values,
+                                # but there are tons of different CloudQuery platforms and tables that
+                                # I haven't looked at, so it's possible that there are cases where this
+                                # won't be the right thing to do, so we may need to revisit this.
+                                if type(attribute_value) == str:
+                                    try:
+                                        attribute_value = yaml.safe_load(attribute_value)
+                                    except yaml.YAMLError as e:
+                                        pass
+                                resource_attributes[attribute_name] = attribute_value
+                            # Call the platform handler to extract the name and qualified name from the
+                            # resource attributes and possibly make alterations to the attributes.
+                            resource_name, qualified_resource_name = \
+                                platform_handler.process_resource_attributes(resource_attributes,
+                                                                             cq_resource_type_spec.resource_type_name,
+                                                                             platform_config_data,
+                                                                             context)
+                            registry.add_resource(cq_platform_spec.name,
+                                                  cq_resource_type_spec.resource_type_name,
+                                                  resource_name,
+                                                  qualified_resource_name,
+                                                  resource_attributes)
 
-            # Convert the tables from the sqlite DB to resources in the resource registry
-            sql_connection = sqlite3.connect(sqlite_database_file_path)
-            cursor = sql_connection.cursor()
-            for cq_platform_spec, cq_resource_type_specs in cq_platform_infos:
-                platform_config_data = cloud_config_data.get(cq_platform_spec.name, dict())
-                platform_handler = platform_handlers[cq_platform_spec.name]
-                for cq_resource_type_spec in cq_resource_type_specs:
-                    # table_name = f"{platform_spec.name}_{resource_type_spec.cloudquery_table_name}"
-                    # table_name = resource_type_spec.cloudquery_table_name
-                    # Extract the fields we need from the sqlite table.
-                    # Would simplify the spec for the platform and I don't think it's really buying us that
-                    # much in terms of performance/efficiency to only fetch a subset, since we'll probably
-                    # always want to get the full instance_view of the resource, which is likely the
-                    # biggest field. So could just do a SELECT * and then use the description field in the
-                    # response to get the field names.
-                    try:
-                        response = cursor.execute(f"SELECT * FROM {cq_resource_type_spec.cloudquery_table_name}")
-                        # response = cursor.execute(f"SELECT {joined_cloudquery_field_names} FROM {table_name}")
-                    except sqlite3.OperationalError as e:
-                        # If no instances of the table were discovered, then the table will not be defined in the
-                        # database, and the SQL execution raises an OperationalError. We don't want to treat
-                        # that as an error, so we just continue in that case.
-                        # FIXME: Are there are other errors that could occur here that we should handle differently?
-                        # Should probably verify that the exception is due to the table not being found.
-                        # Seems like the only way you can do that is to parse the error message, which is sort of ugly.
-                        continue
-                    table_rows = response.fetchall()
-                    field_descriptions = response.description
-                    # resource_name = None
-                    for table_row in table_rows:
-                        # Combine the field descriptions and the row values to set up the resource attributes.
-                        resource_attributes = dict()
-                        for i in range(len(field_descriptions)):
-                            attribute_name = field_descriptions[i][0]
-                            attribute_value = table_row[i]
-                            resource_attributes[attribute_name] = attribute_value
-                        # Call the platform handler to extract the name and qualified name from the
-                        # resource attributes and possibly make alterations to the attributes.
-                        resource_name, qualified_resource_name = \
-                            platform_handler.process_resource_attributes(resource_attributes,
-                                                                         cq_resource_type_spec.resource_type_name,
-                                                                         platform_config_data,
-                                                                         context)
-                        registry.add_resource(cq_platform_spec.name,
-                                              cq_resource_type_spec.resource_type_name,
-                                              resource_name,
-                                              qualified_resource_name,
-                                              resource_attributes)
-
-        logger.debug("CloudQuery indexing ending")
+    logger.info("Finished CloudQuery indexing")

--- a/src/indexers/cloudquery.py.bck
+++ b/src/indexers/cloudquery.py.bck
@@ -1,0 +1,266 @@
+from copy import deepcopy
+from dataclasses import dataclass
+import logging
+import os
+import sqlite3
+import tempfile
+from template import render_template_file
+from typing import Any
+import subprocess
+
+# import models
+from component import Setting, SettingDependency, Context
+from exceptions import WorkspaceBuilderException
+from enrichers.generation_rule_types import PlatformHandler, PLATFORM_HANDLERS_PROPERTY_NAME
+from resources import Registry, REGISTRY_PROPERTY_NAME
+from utils import read_file, write_file
+
+logger = logging.getLogger(__name__)
+
+DOCUMENTATION = "Index resources using CloudQuery"
+
+CLOUD_CONFIG_SETTING = Setting("CLOUD_CONFIG",
+                               "cloudConfig",
+                               Setting.Type.DICT,
+                               "Configuration/credential info for the cloud input sources",
+                               dict())
+
+SETTINGS = (
+    SettingDependency(CLOUD_CONFIG_SETTING, False),
+)
+
+@dataclass
+class CloudQueryResourceTypeSpec:
+    # The name of the resource type in the resource registry
+    resource_type_name: str
+    # The name of the table in the CloudQuery database
+    cloudquery_table_name: str
+    # The fields from the CQ table to incorporate into the resource
+    # FIXME: Potentially support renaming of the fields by making this a dict?
+    fields: dict[str, str]
+
+
+@dataclass
+class CloudQueryPlatformSpec:
+    name: str
+    config_file_name: str
+    # The path/name of the template file used to generate the config file for this platform
+    config_template_name: str
+    environment_variables: dict[str, str]
+    # The info for the resource types supported for this platform
+    resource_type_specs: list[CloudQueryResourceTypeSpec]
+
+
+platform_specs = [
+    CloudQueryPlatformSpec("azure",
+                           config_file_name="azure.yaml",
+                           config_template_name="azure-config.yaml",
+                           environment_variables={
+                               "AZURE_SUBSCRIPTION_ID": "subscriptionId",
+                               "AZURE_TENANT_ID": "tenantId",
+                               "AZURE_CLIENT_ID": "clientId",
+                               "AZURE_CLIENT_SECRET": "clientSecret"
+                           },
+                           resource_type_specs=[
+                               CloudQueryResourceTypeSpec(resource_type_name="ComputeVirtualMachine",
+                                                          cloudquery_table_name="azure_compute_virtual_machines",
+                                                          fields={
+                                                              "name": "name",
+                                                              "tags": "tags",
+                                                              "properties": "properties",
+                                                              "instance": "instance_view",
+                                                          }),
+                           ])
+]
+
+def init_cloudquery_config(cloud_config_data: dict[str, Any],
+                           cloud_config_dir: str,
+                           db_file_path: str) -> dict[str, str]:
+    cq_process_environment_vars = dict()
+
+    # Set up a template loader func to load from the CloudQuery template dir
+    templates_dir = "indexers/cloudquery_templates"
+    template_loader_func = lambda name: read_file(os.path.join(templates_dir, name))
+
+    # Create the sqlite destination config file
+    sqlite_config_path = os.path.join(cloud_config_dir, "sqlite.yaml")
+    template_variables = {"database_path": db_file_path}
+    sqlite_config_text = render_template_file("sqlite-config.yaml", template_variables, template_loader_func)
+    write_file(sqlite_config_path, sqlite_config_text)
+
+    for platform_spec in platform_specs:
+        platform_name = platform_spec.name
+        platform_config_data = cloud_config_data.get(platform_name)
+        if platform_config_data is None:
+            continue
+
+        # Set up any environment variables for the platform
+        for env_var_name, config_name in platform_spec.environment_variables.items():
+            env_var_value = platform_config_data.get(config_name)
+            if env_var_value is not None:
+                cq_process_environment_vars[env_var_name] = env_var_value
+
+        # Start the template variables from the platform config dict. That way the template
+        # for a platform can support platform-specific configuration options without having
+        # to hard-code anything in the platform spec.
+        # NB: We do the deep copy just to be safe, since the root_config_data argument is
+        # owned by the caller, so we shouldn't modify it.
+        template_variables = deepcopy(platform_config_data)
+        template_variables["destination_plugin_name"] = "sqlite"
+        tables = [resource_type_spec.cloudquery_table_name for resource_type_spec in platform_spec.resource_type_specs]
+        template_variables["tables"] = tables
+        config_file_path = os.path.join(cloud_config_dir, platform_spec.config_file_name)
+        config_text = render_template_file(platform_spec.config_template_name, template_variables, template_loader_func)
+        write_file(config_file_path, config_text)
+
+    return cq_process_environment_vars
+
+# def old_init_cloudquery_config(cloud_config_data: dict[str, Any],
+#                            cloud_config_dir: str,
+#                            db_file_path: str) -> dict[str, str]:
+#     # In some cases state is passed to the cloudquery plugins via environment
+#     # variables rather than from the configuration file. Typically, this is
+#     # for auth/credential state, presumably because you don't want to
+#     # require the user to save that sensitive state to the file system.
+#     # So we build up the set of environment variables that will be passed
+#     # to the subprocess we use to run the cloudquery tool.
+#     cq_process_env_vars = dict()
+#
+#     # # Set up a jinja sandbox environment that's used to render the configuration
+#     # # files for the relevant cloudquery plugins.
+#     # jinja_env = SandboxedEnvironment(loader=FileSystemLoader("enrichers/cloudquery_templates"),
+#     #                                  trim_blocks=True, lstrip_blocks=True)
+#
+#     # Set up a template loader func to load from the CloudQuery template dir
+#     templates_dir = "indexers/cloudquery_templates"
+#     template_loader_func = lambda name: read_file(os.path.join(templates_dir, name))
+#
+#     # Create the sqlite destination config file
+#     sqlite_config_path = os.path.join(cloud_config_dir, "sqlite.yaml")
+#     template_variables = {"database_path": db_file_path}
+#     sqlite_config_text = render_template_file("sqlite-config.yaml", template_variables, template_loader_func)
+#     write_file(sqlite_config_path, sqlite_config_text)
+#
+#     azure_config_data = cloud_config_data.get("azure", None)
+#     if azure_config_data:
+#         # Set up the authentication environment variables for Azure
+#         # FIXME: It seems like there can only be one subscription ID here for
+#         # authentication, so why does the config file have fields that indicate
+#         # support for multiple subscriptions. Presumably there must be a way to
+#         # authenticate for multiple subscriptions.
+#         subscription_id = azure_config_data.get("subscriptionId")
+#         tenant_id = azure_config_data.get("tenantId")
+#         client_id = azure_config_data.get("clientId")
+#         client_secret = azure_config_data.get("clientSecret")
+#         if subscription_id and tenant_id and client_id and client_secret:
+#             cq_process_env_vars["AZURE_SUBSCRIPTION_ID"] = subscription_id
+#             cq_process_env_vars["AZURE_TENANT_ID"] = tenant_id
+#             cq_process_env_vars["AZURE_CLIENT_ID"] = client_id
+#             cq_process_env_vars["AZURE_CLIENT_SECRET"] = client_secret
+#         else:
+#             raise WorkspaceBuilderUserException("Incomplete Azure auth configuration")
+#
+#         # Create the CloudQuery config file for Azure
+#         # FIXME: This shouldn't be hard-coded.
+#         # It should come from the load of the gen rules to know which tables are being used
+#         tables = ["compute_virtual_machines"]
+#         template_variables = {
+#             "destination_plugin_name": "sqlite",
+#             "tables": [f"azure_{table_name}" for table_name in tables]
+#         }
+#         subscriptions = azure_config_data.get("subscriptions")
+#         if subscriptions:
+#             template_variables["subscriptions"] = subscriptions
+#         skip_subscriptions = azure_config_data.get("skipSubscriptions")
+#         if skip_subscriptions:
+#             template_variables["skip_subscriptions"] = skip_subscriptions
+#
+#         azure_config_path = os.path.join(cloud_config_dir, "azure.yaml")
+#         azure_config_text = render_template_file("azure-config.yaml", template_variables, template_loader_func)
+#         write_file(azure_config_path, azure_config_text)
+#
+#     return cq_process_env_vars
+
+
+
+def index(context: Context):
+    logger.debug("CloudQuery indexing beginning")
+
+    cloud_config_data = context.get_setting("CLOUD_CONFIG")
+    if not cloud_config_data:
+        return
+
+    platform_handlers: dict[str, PlatformHandler] = context.get_property(PLATFORM_HANDLERS_PROPERTY_NAME)
+
+    registry: Registry = context.get_property(REGISTRY_PROPERTY_NAME)
+    with tempfile.TemporaryDirectory() as cq_temp_dir:
+        # Create a config directory in the temp directory where we'll put all the CloudQuery config files
+        cloudquery_config_dir = os.path.join(cq_temp_dir, "config")
+        os.makedirs(cloudquery_config_dir)
+
+        # Create the CloudQuery source/destination config files
+        sqlite_database_file_path = os.path.join(cq_temp_dir, "db.sql")
+        env_vars = init_cloudquery_config(cloud_config_data, cloudquery_config_dir, sqlite_database_file_path)
+
+        # Invoke CloudQuery to scan for resources from all the configured platforms
+        path = os.getenv("PATH")
+        env_vars["PATH"] = path
+        try:
+            process_info = subprocess.run(["cloudquery", "sync", f"{cloudquery_config_dir}"], capture_output=True, env=env_vars)
+        except Exception as e:
+            raise e
+
+        # Convert the tables from the sqlite DB to resources in the resource registry
+        sql_connection = sqlite3.connect(sqlite_database_file_path)
+        cursor = sql_connection.cursor()
+        for platform_spec in platform_specs:
+            platform_handler = platform_handlers[platform_spec.name]
+            for resource_type_spec in platform_spec.resource_type_specs:
+                # table_name = f"{platform_spec.name}_{resource_type_spec.cloudquery_table_name}"
+                table_name = resource_type_spec.cloudquery_table_name
+                # Extract the fields we need from the sqlite table.
+                # It looks like the results from the "keys" and "items" methods for the dict return
+                # things in a consistent order, so in theory we could just use those, but it's unclear
+                # whether that's something that's guaranteed or just an implementation detail, so we
+                # do use items() both here (which determines the order of the fields in the rows
+                # returned from the SELECT query) and below when we use the field values from the
+                # row to initialize the resource attributes.
+                # FIXME: There's probably a more Pythonic way to do this using zip or something like that.
+                cloudquery_field_names = [field_name for _, field_name in resource_type_spec.fields.items()]
+                joined_cloudquery_field_names = ", ".join(cloudquery_field_names)
+                try:
+                    response = cursor.execute(f"SELECT {joined_cloudquery_field_names} FROM {table_name}")
+                except sqlite3.OperationalError as e:
+                    # If no instances of the table were discovered, then the table will not exist in the
+                    # database, and the SQL execution raises an OperationalError. We don't want to treat
+                    # that as an error, so we just continue in that case.
+                    # FIXME: Are there are other errors that could occur here that we should handle differently?
+                    # Should probably verify that the exception is due to the table not being found.
+                    # Seems like the only way you can do that is to parse the error message, which is sort of ugly.
+                    # FIXME: Revisit this, because this was added when there was a bug with the construction
+                    # of the table name, so it's possible
+                    continue
+                table_rows = response.fetchall()
+                resource_name = None
+                for table_row in table_rows:
+                    # Use the values from the row to set up the resource attributes
+                    resource_attributes = dict()
+                    for i, item in enumerate(resource_type_spec.fields.items()):
+                        attribute_name = item[0]
+                        if attribute_name == "name":
+                            resource_name = attribute_name
+                        else:
+                            resource_attributes[attribute_name] = table_row[i]
+                    if not resource_name:
+                        raise WorkspaceBuilderException("No name specified for a resource indexed by CloudQuery")
+                    qualified_resource_name = platform_handler.get_qualified_name(resource_name, resource_attributes)
+                    # FIXME: Probably need some extra logic here to create a properly qualified resource
+                    # name for platforms that support a scoping/namespace mechanism. Need to investigate
+                    # exactly how this works for various platforms like Azure.
+                    registry.add_resource(platform_spec.name,
+                                          resource_type_spec.resource_type_name,
+                                          resource_name,
+                                          qualified_resource_name,
+                                          resource_attributes)
+
+        logger.debug("CloudQuery indexing ending")

--- a/src/indexers/cloudquery_templates/azure-config.yaml
+++ b/src/indexers/cloudquery_templates/azure-config.yaml
@@ -3,7 +3,7 @@ spec:
   # Source spec section
   name: "azure"
   path: "cloudquery/azure"
-  version: "v9.3.7"
+  version: "v11.0.2"
   destinations: ["{{destination_plugin_name}}"]
   tables: [
     {% for table_name in tables %}

--- a/src/indexers/cloudquery_templates/azure-config.yaml
+++ b/src/indexers/cloudquery_templates/azure-config.yaml
@@ -3,7 +3,7 @@ spec:
   # Source spec section
   name: "azure"
   path: "cloudquery/azure"
-  version: "v11.0.2"
+  version: "v9.4.0"
   destinations: ["{{destination_plugin_name}}"]
   tables: [
     {% for table_name in tables %}

--- a/src/indexers/cloudquery_templates/azure-config.yaml
+++ b/src/indexers/cloudquery_templates/azure-config.yaml
@@ -1,0 +1,29 @@
+kind: source
+spec:
+  # Source spec section
+  name: "azure"
+  path: "cloudquery/azure"
+  version: "v9.3.7"
+  destinations: ["{{destination_plugin_name}}"]
+  tables: [
+    {% for table_name in tables %}
+    "{{table_name}}",
+    {% endfor %}
+  ]
+  spec:
+    # Optional parameters
+    subscriptions: [
+      {% for subscription in subscriptions %}
+      "{{subscription}}",
+      {% endfor %}
+    ]
+    # cloud_name: ""
+    # concurrency: 50000
+    # discovery_concurrency: 400
+    skip_subscriptions: [
+      {% for subscription in skip_subscriptions %}
+      "{{subscription}}",
+      {% endfor %}
+    ]
+    # normalize_ids: false
+    # oidc_token: ""

--- a/src/indexers/cloudquery_templates/sqlite-config.yaml
+++ b/src/indexers/cloudquery_templates/sqlite-config.yaml
@@ -1,0 +1,7 @@
+kind: destination
+spec:
+  name: sqlite
+  path: cloudquery/sqlite
+  version: "v2.4.10"
+  spec:
+    connection_string: {{database_path}}

--- a/src/indexers/kubeapi.py
+++ b/src/indexers/kubeapi.py
@@ -84,7 +84,7 @@ class GroupVersionInfo:
 
 
 def index(component_context: Context):
-    logger.debug("starting kube API scan")
+    logger.debug("Starting kube API scan")
 
     # Access the settings/properties that we need
     kubeconfig_path = component_context.get_setting("KUBECONFIG")

--- a/src/indexers/kubeapi.py
+++ b/src/indexers/kubeapi.py
@@ -66,7 +66,7 @@ DOCUMENTATION = "Index assets from a Kubernetes configuration"
 # in the first part by the user in their local environment.
 # Need to think about this some more...
 SETTINGS = (
-    SettingDependency(KUBECONFIG_SETTING, True),
+    SettingDependency(KUBECONFIG_SETTING, False),
     SettingDependency(NAMESPACES_SETTING, False),
     SettingDependency(NAMESPACE_LODS_SETTING, False),
     SettingDependency(DEFAULT_LOD_SETTING, False)
@@ -88,6 +88,9 @@ def index(component_context: Context):
 
     # Access the settings/properties that we need
     kubeconfig_path = component_context.get_setting("KUBECONFIG")
+    if not kubeconfig_path:
+        return
+
     namespace_lods = component_context.get_setting("NAMESPACE_LODS")
     custom_namespace_names = component_context.get_setting("NAMESPACES")
     default_lod = component_context.get_setting("DEFAULT_LOD")

--- a/src/renderers/dump_resources.py
+++ b/src/renderers/dump_resources.py
@@ -3,8 +3,9 @@ from typing import Any
 import yaml
 
 from component import Context
-from resources import Registry, REGISTRY_PROPERTY_NAME
+from resources import Resource, Registry, REGISTRY_PROPERTY_NAME
 from indexers.kubetypes import KUBERNETES_PLATFORM, KubernetesResourceType, get_cluster
+from enrichers.generation_rule_types import LevelOfDetail
 
 DOCUMENTATION = "Render/dump Kubernetes resource state to a YAML file"
 
@@ -18,34 +19,88 @@ def _dump_resource_state(registry: Registry, resource_type_name: str, cluster_na
     return instances
 
 
+def resource_ref_representer(dumper: yaml.SafeDumper, resource: Resource) -> yaml.nodes.MappingNode:
+    return dumper.represent_str(resource.qualified_name)
+
+def level_of_detail_representer(dumper: yaml.SafeDumper, level_of_detail: LevelOfDetail) -> yaml.nodes.MappingNode:
+    return dumper.represent_str(level_of_detail.name.lower())
+
 def render(context: Context):
-    registry = context.properties[REGISTRY_PROPERTY_NAME]
+    registry: Registry = context.properties[REGISTRY_PROPERTY_NAME]
 
     # Initialize the top-level state in the dump dict
     dump = dict()
     dump['creationDate'] = datetime.datetime.now(datetime.timezone.utc).isoformat()
-    dump['description'] = "Dump of the Kubernetes resources collected during a run of the map generation tool"
-    clusters = dict()
-    dump['clusters'] = clusters
+    dump['description'] = "Dump of the resources collected during a run of the workspace builder tool"
 
     # Iterate over the clusters. The other Kubernetes objects are contained/scoped within each
     # cluster entry to handle resources with the same name across different clusters.
+    # FIXME: This next block of stuff that's added to the dump is backwards compatibility code
+    # to support the format used before the switch from using neo4j to the new resource registry.
+    # Once everything (which should just be the RWL cheat sheet stuff) has switched over to the
+    # new dump format we can get rid of this Kubernetes-specific dump format.
+    clusters = dict()
+    dump['clusters'] = clusters
     cluster_resource_type = registry.lookup_resource_type(KUBERNETES_PLATFORM, KubernetesResourceType.CLUSTER.value)
-    for cluster in cluster_resource_type.instances.values():
-        cluster_dump = dict()
-        cluster_name = cluster.name
-        cluster_dump['context'] = cluster.context
-        clusters[cluster_name] = cluster_dump
+    if cluster_resource_type:
+        for cluster in cluster_resource_type.instances.values():
+            cluster_dump = dict()
+            cluster_name = cluster.name
+            cluster_dump['context'] = cluster.context
+            clusters[cluster_name] = cluster_dump
 
-        # Dump the resources that belong to the current cluster
-        cluster_dump['namespaces'] = _dump_resource_state(registry, KubernetesResourceType.NAMESPACE.value, cluster_name)
-        cluster_dump['ingresses'] = _dump_resource_state(registry, KubernetesResourceType.INGRESS.value, cluster_name)
-        cluster_dump['services'] = _dump_resource_state(registry, KubernetesResourceType.SERVICE.value, cluster_name)
-        cluster_dump['deployments'] = _dump_resource_state(registry, KubernetesResourceType.DEPLOYMENT.value, cluster_name)
-        cluster_dump['statefulSets'] = _dump_resource_state(registry, KubernetesResourceType.STATEFUL_SET.value, cluster_name)
-        cluster_dump['daemonSets'] = _dump_resource_state(registry, KubernetesResourceType.DAEMON_SET.value, cluster_name)
-        cluster_dump['pods'] = _dump_resource_state(registry, KubernetesResourceType.POD.value, cluster_name)
-        cluster_dump['pvcs'] = _dump_resource_state(registry, KubernetesResourceType.PVC.value, cluster_name)
+            # Dump the resources that belong to the current cluster
+            cluster_dump['namespaces'] = _dump_resource_state(registry, KubernetesResourceType.NAMESPACE.value, cluster_name)
+            cluster_dump['ingresses'] = _dump_resource_state(registry, KubernetesResourceType.INGRESS.value, cluster_name)
+            cluster_dump['services'] = _dump_resource_state(registry, KubernetesResourceType.SERVICE.value, cluster_name)
+            cluster_dump['deployments'] = _dump_resource_state(registry, KubernetesResourceType.DEPLOYMENT.value, cluster_name)
+            cluster_dump['statefulSets'] = _dump_resource_state(registry, KubernetesResourceType.STATEFUL_SET.value, cluster_name)
+            cluster_dump['daemonSets'] = _dump_resource_state(registry, KubernetesResourceType.DAEMON_SET.value, cluster_name)
+            cluster_dump['pods'] = _dump_resource_state(registry, KubernetesResourceType.POD.value, cluster_name)
+            cluster_dump['pvcs'] = _dump_resource_state(registry, KubernetesResourceType.PVC.value, cluster_name)
 
+    # Dump all the info in the registry
+    # Note that the Kubernetes-specific info will be duplicated in this part of the dump.
+    # The Kubernetes-specific dump code above is the old way the info was dumped and is just
+    # kept around for the time being in case anything (e.g. the cheat sheet stuff) is still
+    # using it. Should check with Shea if he's dependent on it.
+    # Anyway, eventually (hopefully soon) nothing will be using the old dump content and
+    # we can get rid of the stuff above.
+    # FIXME: There's probably a somewhat cleaner way to do this dump, presumably using the
+    # mechanism built into the yaml module to customize how it dumps objects. I spent a
+    # little bit of time looking into that, but it seemed like it was going to be more
+    # work than just doing the code below. Possibly when I get around to doing supporting
+    # a dump/load mechanism for the resource registry it will make sense to revisit this
+    # and presumably leverage the dump code here.
+    platforms_dump = list()
+    dump['platforms'] = platforms_dump
+    for platform in registry.platforms.values():
+        resource_types_dump = list()
+        platform_dump = {
+            "name": platform.name,
+            "resourceTypes": resource_types_dump
+        }
+        platforms_dump.append(platform_dump)
+        for resource_type in platform.resource_types.values():
+            instances_dump = list()
+            resource_type_dump = {
+                "name": resource_type.name,
+                "instances": instances_dump
+            }
+            resource_types_dump.append(resource_type_dump)
+            for instance in resource_type.instances.values():
+                instance_dump = dict()
+                instances_dump.append(instance_dump)
+                attributes_names = dir(instance)
+                for attribute_name in attributes_names:
+                    if attribute_name.startswith("__") or attribute_name == "resource_type":
+                        continue
+                    attribute_value = getattr(instance, attribute_name)
+                    if callable(attribute_value):
+                        continue
+                    instance_dump[attribute_name] = attribute_value
+
+    yaml.SafeDumper.add_representer(Resource, resource_ref_representer)
+    yaml.SafeDumper.add_representer(LevelOfDetail, level_of_detail_representer)
     dump_text = yaml.safe_dump(dump)
     context.outputter.write_file("resource-dump.yaml", dump_text)

--- a/src/run.sh
+++ b/src/run.sh
@@ -35,7 +35,7 @@ fi
 touch "$LOCK_FILE"
 
 # Run the Python script with your specified arguments
-python3 run.py run --components "kubeapi,runwhen_default_workspace,generation_rules,render_output_items,dump_resources" $@
+python3 run.py run --components "kubeapi,cloudquery,runwhen_default_workspace,generation_rules,render_output_items,dump_resources" $@
 
 # Remove the lock file after the Python script exits
 rm -f "$LOCK_FILE"

--- a/src/utils.py
+++ b/src/utils.py
@@ -1,7 +1,8 @@
 import datetime
 import json
+import os
 from collections.abc import Sequence
-from typing import Any
+from typing import Any, AnyStr, Union
 
 from kubernetes.dynamic.resource import ResourceInstance
 
@@ -105,9 +106,20 @@ def kubernetes_resource_to_dict(resource: ResourceInstance, use_attribute_map: b
     obj = json.loads(json_str)
     return obj
 
+def read_file(file_path: AnyStr, mode="r", encoding=None) -> Union[str, bytes]:
+    with open(file_path, mode=mode, encoding=encoding) as f:
+        return f.read()
+
+def write_file(path: AnyStr, data: AnyStr) -> None:
+    directory_path, _ = os.path.split(path)
+    os.makedirs(directory_path, exist_ok=True)
+    mode = "wb" if type(data) == bytes else "w"
+    with open(path, mode=mode) as f:
+        f.write(data)
 
 def get_version_info() -> dict[str, Any]:
-    with open("VERSION", encoding="utf8") as f:
-        json_info = f.read()
+    json_info = read_file("VERSION", encoding="utf8")
+    # with open("VERSION", encoding="utf8") as f:
+    #     json_info = f.read()
     info = json.loads(json_info)
     return info

--- a/src/workspace_builder/tests.py
+++ b/src/workspace_builder/tests.py
@@ -27,38 +27,48 @@ BASE_REQUEST_DATA = {
     "defaultWorkspaceName": "my-workspace",
     "workspaceName": "my-workspace",
     "workspaceOwnerEmail": "test@runwhen.com",
-    # "kubeconfig": "kubeconfig",
+    "kubeconfig": "kubeconfig",
     "workspaceOutputPath": "workspace",
     "defaultLocation": "northamerica-northeast2-01",
     "mapCustomizationRules": "map-customization-rules-test",
     "codeCollections": [
-        {"repoURL": f"file://{git_repo_root}/rw-public-codecollection", "branch": "main"},
-        {"repoURL": f"file://{git_repo_root}/rw-cli-codecollection", "branch": "main"}
+        "https://github.com/runwhen-contrib/rw-cli-codecollection",
+        "https://github.com/runwhen-contrib/rw-public-codecollection"
+        # {"repoURL": f"file://{git_repo_root}/rw-public-codecollection", "branch": "main"},
+        # {"repoURL": f"file://{git_repo_root}/rw-cli-codecollection", "branch": "main"}
         # , "codeBundles": ["k8s-namespace-healthcheck"]
+        # {
+        #     "repoURL": f"file://{git_repo_root}/rw-cli-codecollection",
+        #     "branch": "robv-azure-test",
+        #     "codeBundles": ["az-vm-healthcheck"],
+        # },
         # {
         #     "repoURL": "https://github.com/runwhen-contrib/rw-cli-codecollection",
         #     "branch": "main",
         #     "codeBundles": ["k8s-namespace-healthcheck"],
-        # }
+        # },
     ],
-    "cloudConfig": {
-        "azure": {
-            # To enable testing of the cloudquery Azure indexing you need to
-            # define the 4 environments variables below either in the shell from
-            # which you're running the test or the run configuration in whatever
-            # IDE you're using. These environment variables are described in the
-            # documentation for the CloudQuery Azure plugin:
-            # https://hub.cloudquery.io/plugins/source/cloudquery/azure/v9.3.7/docs
-            "subscriptionId": os.getenv("WB_AZURE_SUBSCRIPTION_ID"),
-            "tenantId": os.getenv("WB_AZURE_TENANT_ID"),
-            "clientId": os.getenv("WB_AZURE_CLIENT_ID"),
-            "clientSecret": os.getenv("WB_AZURE_CLIENT_SECRET"),
-        },
-        "kubernetes": {
-            "kubeconfig": "kubeconfig",
-            "namespaceLODs": {"kube-system": 0, "kube-public": 0},
-        }
-    }
+    # "cloudConfig": {
+    #     "azure": {
+    #         # To enable testing of the cloudquery Azure indexing you need to
+    #         # define the 4 environments variables below either in the shell from
+    #         # which you're running the test or the run configuration in whatever
+    #         # IDE you're using. These environment variables are described in the
+    #         # documentation for the CloudQuery Azure plugin:
+    #         # https://hub.cloudquery.io/plugins/source/cloudquery/azure/v9.3.7/docs
+    #         "subscriptionId": os.getenv("WB_AZURE_SUBSCRIPTION_ID"),
+    #         "tenantId": os.getenv("WB_AZURE_TENANT_ID"),
+    #         "clientId": os.getenv("WB_AZURE_CLIENT_ID"),
+    #         "clientSecret": os.getenv("WB_AZURE_CLIENT_SECRET"),
+    #         "resourceGroupLevelOfDetails": {
+    #             "WorkspaceBuilderTesting": "basic"
+    #         }
+    #     },
+    #     # "kubernetes": {
+    #     #     "kubeconfig": "kubeconfig",
+    #     #     "namespaceLODs": {"kube-system": 0, "kube-public": 0},
+    #     # }
+    # }
 
 }
 

--- a/src/workspace_builder/tests.py
+++ b/src/workspace_builder/tests.py
@@ -27,7 +27,7 @@ BASE_REQUEST_DATA = {
     "defaultWorkspaceName": "my-workspace",
     "workspaceName": "my-workspace",
     "workspaceOwnerEmail": "test@runwhen.com",
-    "kubeconfig": "kubeconfig",
+    # "kubeconfig": "kubeconfig",
     "workspaceOutputPath": "workspace",
     "defaultLocation": "northamerica-northeast2-01",
     "mapCustomizationRules": "map-customization-rules-test",
@@ -40,7 +40,26 @@ BASE_REQUEST_DATA = {
         #     "branch": "main",
         #     "codeBundles": ["k8s-namespace-healthcheck"],
         # }
-    ]
+    ],
+    "cloudConfig": {
+        "azure": {
+            # To enable testing of the cloudquery Azure indexing you need to
+            # define the 4 environments variables below either in the shell from
+            # which you're running the test or the run configuration in whatever
+            # IDE you're using. These environment variables are described in the
+            # documentation for the CloudQuery Azure plugin:
+            # https://hub.cloudquery.io/plugins/source/cloudquery/azure/v9.3.7/docs
+            "subscriptionId": os.getenv("WB_AZURE_SUBSCRIPTION_ID"),
+            "tenantId": os.getenv("WB_AZURE_TENANT_ID"),
+            "clientId": os.getenv("WB_AZURE_CLIENT_ID"),
+            "clientSecret": os.getenv("WB_AZURE_CLIENT_SECRET"),
+        },
+        "kubernetes": {
+            "kubeconfig": "kubeconfig",
+            "namespaceLODs": {"kube-system": 0, "kube-public": 0},
+        }
+    }
+
 }
 
 def read_file(file_path: str, mode="r") -> Union[str, bytes]:
@@ -126,7 +145,7 @@ class ProductionComponentTestCase(TestCase):
         archive.extractall(TEST_OUTPUT_DIRECTORY)
 
     def test_generation_rules_workspace_gen(self):
-        self.run_common("kubeapi,runwhen_default_workspace,generation_rules,render_output_items")
+        self.run_common("kubeapi,cloudquery,runwhen_default_workspace,generation_rules,render_output_items")
 
     # Need to implement some sort of dump/load feature to the resource registry
     # for this to make sense now that we're not using neo4j anymore.

--- a/src/workspace_builder/views.py
+++ b/src/workspace_builder/views.py
@@ -69,6 +69,7 @@ class RunView(APIView):
                 if value is not None:
                     if setting.type == Setting.Type.FILE and not using_default_value:
                         try:
+                            # FIXME: Fix the problem with the type inferencing for "value" to address the type warning
                             tar_stream = io.BytesIO(value)
                             archive = tarfile.open(fileobj=tar_stream, mode="r")
                             setting_temp_directory = tempfile.TemporaryDirectory()
@@ -95,10 +96,6 @@ class RunView(APIView):
             outputter = TarFileOutputter()
             context = Context(setting_values, outputter)
             context.set_property(REGISTRY_PROPERTY_NAME, Registry())
-            # FIXME: This should call component.run_components to avoid code duplication.
-            # Would need to resolve differences in how they're called, i.e. separate lists for
-            # the indexers, enrichers, renders, vs. a single list.
-            # (Or else should get rid of run_components).
             run_components(context, components)
 
             outputter.close()


### PR DESCRIPTION
This is the third pass at my previous CloudQuery PR. This has pretty much feature parity with what you can do with the Kubernetes indexer. It sets up similar template variables and you can do the same things in match predicates. Azure uses the term "tag" instead of the Kubernetes "labels" and "annotations", so for tag-based match predicates you use the terms "tags", "tag-keys", and "tag-values" to match against the tags.

I've testing this with the docker image and the workspace builder part of it works correctly, but I get an error in the cheat sheet generation part of things, which Shea can hopefully help me diagnose.

I still need to write up some more complete documentation about how to configure everything and how these changes affect gen rule authors.

Here's what my test CloudQuery/Azure gen rules file looked like, just to get a taste:
```
apiVersion: runwhen.com/v1
kind: GenerationRules
spec:
  platform: azure
  generationRules:
    - resourceTypes:
        - virtual_machine
      matchRules:
        - type: pattern
          pattern: ".+"
          properties: [name]
          mode: substring
      slxs:
        - baseName: vm-health
          levelOfDetail: basic
          qualifiers: [resource_group]
          baseTemplateName: az-vm-health
          outputItems:
            - type: slx
            - type: runbook
              templateName: az-vm-health-taskset.yaml
    - resourceTypes:
        - virtual_machine
      matchRules:
        - type: pattern
          pattern: "Another"
          properties: [tags]
          mode: substring
      slxs:
        - baseName: vm-health2
          levelOfDetail: basic
          qualifiers: [resource_group]
          baseTemplateName: az-vm-health
          outputItems:
            - type: slx
            - type: runbook
              templateName: az-vm-health-taskset.yaml
    - resourceTypes:
        - virtual_machine
      matchRules:
        - type: pattern
          pattern: "Linux"
          properties: [computerName]
          mode: substring
      slxs:
        - baseName: vm-health3
          levelOfDetail: basic
          qualifiers: [resource_group]
          baseTemplateName: az-vm-health
          outputItems:
            - type: slx
            - type: runbook
              templateName: az-vm-health-taskset.yaml
```
Below are the more detailed comments from the commit messages:
```
    - lookup setting values by setting variable as well as just the name
    - currently only has configuration/spec for the Azure platform (and only
      a small number of tables/resource-types), but it's easy to add more.
    - made some changes to the PlatformHandler interface to construct
      qualified resource name by delegating to the handler.
    - implemented code in the Azure platform handler to obtain the resource
      group for the resource and use that to construct the qualified name.
    - updated the Dockerfile to install the cloudquery CLI. Note that this
      only pre-installs the CLI itself. The platform plugins that are used
      are downloaded/installed dynamically. I think that should be ok, but
      we'll have to see.
    - I did the development of this before they released a new major version
      (4.0) a couple of weeks ago, so currently we're pinned to the specific
      older versions of the CLI and Azure plugin, since that's what I
      developed against. I need to look more into what the changes were for the
      new version and what changes I need to make to work with that. Although
      since it's a brand new major version we probably want to wait a while
      in case there are any problems with the new code.

    - fixed bugs with resource group support
    - finished implementation of the Azure platform handler
    - deserialize the Azure resource tags and instance_view so that the data
      is accessible from templates and match rules
    - support for tag-based match rules modeled on the Kubernetes labels and
      annotations. It works exactly the same way except that the property
      names are "tags", "tag-keys", and "tag-values"
    - path-based matches work in a similar way too. The resource data is
      initialized from the "instance_view" field from the Azure CloudQuery
      table. This was set for the virtual machine table, but I need to check
      other table types to see if this is the standard name that is used or
      if other tables should use a different name.
    - added code to be smarter about which tables are configured in the
      per-platform CloudQuery config files, i.e. only include the tables
      that are actually referenced by gen rules, plus mandatory tables that
      are always indexed since they may be referenced by other resource
      types, e.g. resource groups for Azure
    - fixed some bugs in the handling of the standard/built-in template
      variable names. Also, made sure they were set for the template
      variables that are passed to the customization rules.
    - fixed a few other places in the gen rules code that were doing
      Kubernetes-specific things, e.g. looking up a namespace

    - updated run.py to include the cloudConfig block from workspaceInfo in
      the request data to the workspace builder REST service
    - removed obsolete components from the default values for the components
      argument in run.py
    - fixed some bugs with execution of run.py with the cheat sheet disabled
    - make the kubeconfig setting and Kubernetes indexing optional, since
      you might just want to do CloudQuery indexing
    - added the cloudquery indexer component to the run.sh script
    - updated the dump_resources component to dump the entire contents of the
      resource registry, not just the Kubernetes resources. The old
      Kubernetes-specific data is still included for backwards compatibility
      but will be removed as soon as I know that nothing's using it
    - made some changes to the cheat sheet status updates from run.py to try
      to get it to work in my local dev context, but unfortunately there's
      still some code that hard-codes the /shared base path so it doesn't
      completely work
```