### PR TITLE
Fix/double-render

### DIFF
--- a/src/VERSION
+++ b/src/VERSION
@@ -1,4 +1,4 @@
 {
   "name":    "runwhen-local",
-  "version": "0.4.2"
+  "version": "0.4.3"
 }

--- a/src/cheat-sheet-docs/docs/overrides/main.html
+++ b/src/cheat-sheet-docs/docs/overrides/main.html
@@ -9,6 +9,16 @@
       </div>
     </div>
   {% endif %}
+    <div id="feedback-banner" class="fade-announcement">
+      <div class="fade-announcement-text">
+        📢   Your feedback is is valuable! Chat with us about improving RunWhen Local and <a href="https://github.com/orgs/runwhen-contrib/discussions/391" target="_blank"><b>receive a $100 Amazon Gift Card</b></a> in return! <button onclick="closeBanner()" style="color: white"> &nbsp &nbsp &nbsp &nbsp Hide Banner</button>
+        <script>
+          function closeBanner() {
+            document.getElementById('feedback-banner').style.display = 'none';
+          }
+        </script>
+      </div>
+    </div>
 {% endblock %}
 
 {% block content %}

--- a/src/cheatsheet.py
+++ b/src/cheatsheet.py
@@ -345,7 +345,7 @@ def search_keywords(parsed_robot, parsed_runbook_config, search_list, meta):
 
                         if is_unique_command(commands, command):
                             commands.append(command)
-
+    return commands
 
 def parse_yaml (fpath):
     with open(fpath, 'r') as file:
@@ -446,47 +446,6 @@ def update_last_scan_time():
     except Exception as e:
         print(f"An error occurred while updating the file: {e}")
 
-# def discovery_summary(resource_dump_file):
-#     summary = {}
-#     try:
-#         with open(resource_dump_file, 'r') as file:
-#             data = yaml.safe_load(file)
-            
-#             # Summarize Clusters
-#             clusters = data["clusters"]
-#             summary["num_clusters"] = len(clusters)
-#             summary["cluster_names"] = list(clusters.keys())
-
-#             total_ingresses = 0
-#             total_namespaces = 0
-#             total_pods = 0 
-#             total_daemonsets = 0 
-#             total_statefulsets = 0 
-#             for cluster in clusters.values():
-#                 ingresses = cluster.get('ingresses', [])
-#                 total_ingresses += len(ingresses)
-#                 namespaces = cluster.get('namespaces', [])
-#                 total_namespaces += len(namespaces)
-#                 pods = cluster.get('pods', [])
-#                 total_pods += len(pods)
-#                 daemonsets = cluster.get('daemonSets', [])
-#                 total_daemonsets += len(daemonsets)
-#                 statefulsets = cluster.get('statefulSets', [])
-#                 total_statefulsets += len(statefulsets)
-
-#             summary["num_namespaces"] = total_namespaces
-#             summary["num_ingresses"] = total_ingresses
-#             summary["num_pods"] = total_pods
-#             summary["num_daemonsets"] = total_daemonsets
-#             summary["num_statefulsets"] = total_statefulsets
-
-
-#             return summary
-            
-#     except FileNotFoundError:
-#         print("Resource Dump File not found.")
-#     except yaml.YAMLError as e:
-#         print(f"Error while parsing YAML: {e}")  
     
 
 def generate_index(summarized_resources, workspace_details, command_generation_summary_stats, slx_count): 

--- a/src/cheatsheet.py
+++ b/src/cheatsheet.py
@@ -314,6 +314,8 @@ def search_keywords(parsed_robot, parsed_runbook_config, search_list, meta):
         meta = {
             "commands": []
         }
+    def is_unique_command(commands, command):
+        return not any(c['name'] == command['name'] and c['command'] == command['command'] for c in commands)
 
     commands = []
     for task in parsed_robot['tasks']:
@@ -321,7 +323,7 @@ def search_keywords(parsed_robot, parsed_runbook_config, search_list, meta):
             if hasattr(keyword, 'name'):
                 for item in search_list:
                     if item in keyword.args:
-                        task_name=task_name_expansion(task["name"], parsed_runbook_config)
+                        task_name = task_name_expansion(task["name"], parsed_runbook_config)
                         task_name_generalized = task["name"].replace('`', '').replace('${', '').replace('}', '')
                         name_snake_case = re.sub(r'\W+', '_', task_name_generalized.lower())
                         command = {
@@ -340,8 +342,10 @@ def search_keywords(parsed_robot, parsed_runbook_config, search_list, meta):
                             command['explanation'] = "No command explanation available"  # Executed if no match is found
                             command['multi_line_details'] = "No multi-line explanation available"
                             command['doc_links'] = []
-                        commands.append(command)
-    return commands
+
+                        if is_unique_command(commands, command):
+                            commands.append(command)
+
 
 def parse_yaml (fpath):
     with open(fpath, 'r') as file:

--- a/src/map-customization-rules/namespace-based-rules.yaml
+++ b/src/map-customization-rules/namespace-based-rules.yaml
@@ -82,3 +82,9 @@ spec:
         pattern: "sa-check"
         matchMode: substring
       group: "{{namespace.name}} ({{cluster.name}})"
+    - match:
+        type: pattern
+        matchType: base-name
+        pattern: "loki-hlthck"
+        matchMode: substring
+      group: "{{namespace.name}} ({{cluster.name}})"


### PR DESCRIPTION
As we introduced some backwards compatibillity into how tasks are flagged for rendering in the cheat sheet, we ended up with some duplicates. This patch removes deplicates from the command list that is rendered - fixing https://github.com/runwhen-contrib/runwhen-local/issues/398

It also adds a banner, which will be removed in the future, to notify users of our offer to collect feedback in exchange for a gift card. 
