### PR TITLE
Bash render bugfix

### DIFF
--- a/src/cheatsheet.py
+++ b/src/cheatsheet.py
@@ -161,7 +161,7 @@ def cmd_expansion(keyword_arguments, parsed_runbook_config):
         raw_script_url=generate_raw_git_url(git_url=parsed_runbook_config["spec"]["codeBundle"]["repoUrl"], ref=parsed_runbook_config["spec"]["codeBundle"]["ref"], file_path=file_path)
         env=""
         for var in parsed_runbook_config["spec"]["configProvided"]:
-            env += f"{var['name']}={var['value']};"
+            env += f"{var['name']}={var['value']} "
         matched_cmd_override = None
         for arg in cmd_components:
             arg=arg.strip()
@@ -174,9 +174,9 @@ def cmd_expansion(keyword_arguments, parsed_runbook_config):
             cmd_parts=matched_cmd_override.split()
             cmd_arguments=' '.join(cmd_parts[1:])
             cmd_arguments=cmd_arguments.strip("'")
-            cmd_components[0]=f"{env} curl -s {raw_script_url} | bash -s {cmd_arguments}"
+            cmd_components[0]=f"{env} bash -c \"$(curl -s {raw_script_url})\" _ {cmd_arguments}"
         else: 
-            cmd_components[0]=f"{env} curl -s {raw_script_url} | bash"
+            cmd_components[0]=f"{env} bash -c \"$(curl -s {raw_script_url})\" _"
         logger.debug(f"Rendering bash file after split: {cmd_components}") 
         cmd_str=cmd_components[0]      
     else: 


### PR DESCRIPTION
fixes #403

Validated on the cmdline: 
```
NAMESPACE=online-boutique CONTEXT=gke_runwhen-nonprod-sandbox_us-central1_sandbox-cluster-1-cluster KUBERNETES_DISTRIBUTION_BINARY=kubectl DEPLOYMENT_NAME=adservice EXPECTED_AVAILABILITY=1 ANOMALY_THRESHOLD=3 LOGS_ERROR_PATTERN=500 LOGS_EXCLUDE_PATTERN=info  bash -c "$(curl -s https://raw.githubusercontent.com/runwhen-contrib/rw-cli-codecollection/main/codebundles/k8s-deployment-healthcheck/validate_probes.sh)" _ readinessProbe
-------- START Validation - Container Name: server Probe Type: readinessProbe -------
Container: `server`
readinessProbe: {
  "exec": {
    "command": [
      "/bin/grpc_health_probe",
      "-addr=:9555"
    ]
  },
  "failureThreshold": 3,
  "initialDelaySeconds": 20,
  "periodSeconds": 15,
  "successThreshold": 1,
  "timeoutSeconds": 1
}
Exposed Ports: 9555
Container `server`: Port 9555 in readinessProbe exec command is valid.
--- START Exec Test as configured----
Executing command for deployment adservice: /bin/grpc_health_probe -addr=:9555
Command Output: status: SERVING
Exit Code: 0
---- END Exec Test----
------- END Validation - Container Name: server Probe Type: readinessProbe -------

```