### PR TITLE
add workflow template rendering support

### DIFF
--- a/src/VERSION
+++ b/src/VERSION
@@ -1,4 +1,4 @@
 {
   "name":    "runwhen-local",
-  "version": "0.4.3"
+  "version": "0.5.0"
 }


### PR DESCRIPTION
Addresses #406

A "workflow" type template can now be added to generation rules, which will cause a workflow to be created with the name of the slx in the workflows directory. 

Note* Platform level changes are required to read in, visualize, and edit multiple workflow files from the workflows directory rather than a single workflows/workflow.yaml file. 