### PR TITLE
Support for CloudQuery API keys and premium tables

### DIFF
--- a/src/component.py
+++ b/src/component.py
@@ -204,11 +204,13 @@ class Context:
     setting_values: dict[str, Any]
     outputter: Outputter
     properties: dict[str, Any]
+    warnings: list[str]
 
     def __init__(self, setting_values: dict[str, Any], outputter: Outputter):
         self.setting_values = setting_values
         self.outputter = outputter
         self.properties = dict()
+        self.warnings = list()
 
     def get_setting(self, setting: Union[str, Setting]) -> Any:
         if isinstance(setting, str):
@@ -223,6 +225,9 @@ class Context:
 
     def get_property(self, name: str, default_value: Any = None) -> Any:
         return self.properties.get(name, default_value)
+
+    def add_warning(self, warning: str):
+        self.warnings.append(warning)
 
 
 all_settings: dict[str, Setting]

--- a/src/indexers/cloudquery.py
+++ b/src/indexers/cloudquery.py
@@ -1,16 +1,17 @@
 from copy import deepcopy
 from dataclasses import dataclass
+import json
 import logging
 import os
 import sqlite3
 import tempfile
 from template import render_template_file
-from typing import Any
+from typing import Any, Optional, Union
 import subprocess
 import yaml
 
 # import models
-from component import Setting, SettingDependency, Context
+from component import SettingDependency, Context
 from enrichers.generation_rule_types import (
     PlatformHandler,
     PLATFORM_HANDLERS_PROPERTY_NAME,
@@ -22,6 +23,9 @@ from utils import read_file, write_file
 from .common import CLOUD_CONFIG_SETTING
 
 logger = logging.getLogger(__name__)
+
+debug_logging_str = os.environ.get('DEBUG_LOGGING')
+debug_logging = debug_logging_str and debug_logging_str.lower() == 'true'
 
 DOCUMENTATION = "Index resources using CloudQuery"
 
@@ -100,12 +104,112 @@ platform_specs = [
                            ]),
 ]
 
+def invoke_cloudquery(cq_command: str,
+                      cq_config_dir: str,
+                      cq_env_vars: dict[str, str],
+                      cq_output_dir: Optional[str] = None) -> None:
+    # We need to set the PATH environment variable so that the cloudquery CLI can be found
+    path = os.getenv("PATH")
+    cq_env_vars["PATH"] = path
+    common_error_message = "Error running CloudQuery to discover resources"
+    try:
+        # Construct the args to use to invoke the CloudQuery CLI
+        cq_args = ["cloudquery"]
+        if debug_logging:
+            cq_args += ["--log-level", "debug"]
+        cq_args += [cq_command, f"{cq_config_dir}"]
+        if cq_output_dir:
+            cq_args += ["--output-dir", f"{cq_output_dir}"]
+
+        process_info = subprocess.run(cq_args, capture_output=True, env=cq_env_vars)
+
+        # Do some debug logging of the info from the CloudQuery run
+        stderr_text = process_info.stdout.decode('utf-8')
+        stdout_text = process_info.stderr.decode('utf-8')
+        logger.debug("Results for subprocess run of cloudquery:")
+        logger.debug(f"args={process_info.args}")
+        logger.debug(f"return-code={process_info.returncode}")
+        logger.debug(f"stderr: {stderr_text}")
+        logger.debug(f"stdout: {stdout_text}")
+        # If there was a failure code from CloudQuery, then raise an  exception
+        if process_info.returncode != 0:
+            error_message = f"{common_error_message}: " \
+                            f"return-code={process_info.returncode}; " \
+                            f"stderr={stderr_text}; " \
+                            f"stdout={stdout_text}"
+            raise WorkspaceBuilderException(error_message)
+    except Exception as e:
+        error_message = f"{common_error_message}; error launching CloudQuery; {str(e)}"
+        raise WorkspaceBuilderException(error_message) from e
+
+cloudquery_premium_table_info: Optional[dict[str, list[str]]] = None
+
+def get_premium_tables(table_info_list: list[dict[str, Union[str, Any]]]) -> list[str]:
+    premium_tables: list[str] = []
+    for table_info in table_info_list:
+        is_premium = table_info.get("is_paid", False)
+        if is_premium:
+            table_name: str = table_info.get("name")
+            premium_tables.append(table_name)
+        relations: list[dict[str, Union[str, Any]]] = table_info.get("relations")
+        if relations:
+            premium_relation_tables = get_premium_tables(relations)
+            premium_tables += premium_relation_tables
+    return premium_tables
+
+def init_cloudquery_table_info():
+    global cloudquery_premium_table_info
+    if cloudquery_premium_table_info:
+        return
+    with tempfile.TemporaryDirectory() as cq_temp_dir:
+        cq_config_dir = os.path.join(cq_temp_dir, "config")
+        cq_output_dir = os.path.join(cq_temp_dir, "docs")
+        # Set up a template loader func to load from the CloudQuery template dir
+        # FIXME: There's some code duplication here with init_cloudquery_config.
+        # Should refactor a bit to get rid of that.
+        templates_dir = "indexers/cloudquery_templates"
+        template_loader_func = lambda name: read_file(os.path.join(templates_dir, name))
+
+        # Create the sqlite destination config file
+        sqlite_config_path = os.path.join(cq_config_dir, "sqlite.yaml")
+        db_file_path = os.path.join(cq_temp_dir, "db.sql")
+        template_variables = {"database_path": db_file_path}
+        sqlite_config_text = render_template_file("sqlite-config.yaml", template_variables, template_loader_func)
+        write_file(sqlite_config_path, sqlite_config_text)
+
+        template_variables = {
+            "tables": ["*"],
+            "destination_plugin_name": "sqlite",
+        }
+        for platform_spec in platform_specs:
+            config_file_path = os.path.join(cq_config_dir, platform_spec.config_file_name)
+            config_text = render_template_file(platform_spec.config_template_name, template_variables,
+                                               template_loader_func)
+            write_file(config_file_path, config_text)
+
+        cq_env_vars = dict()
+        invoke_cloudquery("tables", cq_config_dir, cq_env_vars, cq_output_dir)
+
+        # Parse the generated table documentation
+        cloudquery_premium_table_info = dict()
+        for platform_spec in platform_specs:
+            table_doc_path = os.path.join(cq_output_dir, platform_spec.name, "__tables.json")
+            table_doc_text = read_file(table_doc_path)
+            table_doc_data = json.loads(table_doc_text)
+            premium_tables = get_premium_tables(table_doc_data)
+            cloudquery_premium_table_info[platform_spec.name] = premium_tables
+
 def init_cloudquery_config(cloud_config_data: dict[str, Any],
                            cloud_config_dir: str,
                            db_file_path: str,
                            accessed_resource_type_specs: dict[str, list[ResourceTypeSpec]]
                            ) -> tuple[dict[str, str], list[tuple[CloudQueryPlatformSpec, list[CloudQueryResourceTypeSpec]]]]:
     cq_process_environment_vars = dict()
+
+    cloudquery_config = cloud_config_data.get("cloudquery", dict())
+    cq_api_key = cloudquery_config.get("apiKey")
+    if cq_api_key:
+        cq_process_environment_vars["CLOUDQUERY_API_KEY"] = cq_api_key
 
     # Set up a template loader func to load from the CloudQuery template dir
     templates_dir = "indexers/cloudquery_templates"
@@ -135,6 +239,7 @@ def init_cloudquery_config(cloud_config_data: dict[str, Any],
                 tables.append(cq_resource_type_spec.cloudquery_table_name)
 
         # cq_resource_type_spec.resource_type_name not in added_mandatory_resource_type_specs
+        premium_tables = cloudquery_premium_table_info.get(platform_spec.name, list())
         for resource_type_spec in accessed_resource_type_specs.get(platform_name, list()):
             resource_type_name = resource_type_spec.resource_type_name
             for cq_resource_type_spec in platform_spec.resource_type_specs:
@@ -143,9 +248,28 @@ def init_cloudquery_config(cloud_config_data: dict[str, Any],
             else:
                 cq_resource_type_spec = CloudQueryResourceTypeSpec(resource_type_name, resource_type_name, False)
             if not cq_resource_type_spec.mandatory:
-                cq_resource_type_specs.append(cq_resource_type_spec)
-                if cq_resource_type_spec.cloudquery_table_name not in tables:
-                    tables.append(cq_resource_type_spec.cloudquery_table_name)
+                table_name = cq_resource_type_spec.cloudquery_table_name
+                if not cq_api_key and table_name in premium_tables:
+                    # FIXME: Ideally here we'd like to report information about the generation rule(s)
+                    # and associated code bundle(s) that are begin skipped because they rely on premium
+                    # tables, but, unfortunately the current data structures for tracking the accessed
+                    # resource types don't keep track of which generation rule(s) were the ones that
+                    # triggered the inclusion of the resource type. So those data structures should be
+                    # tweaked a bit to provide support for that info. So for now we just report the
+                    # table name.
+                    # FIXME: Also, logging at the workspace builder REST service is not the ideal way
+                    # to report these warnings. Ideally, they'd be included in the REST response to
+                    # the client invoking the workspace builder. That way they can be reported
+                    # directly to the user when they make the docker exec call rather than requiring
+                    # them to go through the docker container logs, which they may not even have
+                    # access to. So there should be a mechanism for accumulating warning messages
+                    # in the context that are then reported back in the response.
+                    logger.warning('Suppressing access to premium table "%s"; '
+                                   'an account and API key is required for access.")', table_name)
+                else:
+                    cq_resource_type_specs.append(cq_resource_type_spec)
+                    if table_name not in tables:
+                        tables.append(table_name)
 
         if len(cq_resource_type_specs) == 0:
             continue
@@ -195,10 +319,22 @@ def transform_cloud_config(cloud_config: dict[str, Any],
 def index(context: Context):
     logger.info("Starting CloudQuery indexing")
 
+    # FIXME: Ideally this should just get called once on startup, since it's independent of
+    # the parameters for any particular request. But for now there's just a check on the global
+    # variable to short-circuit repeated invocations.
+    init_cloudquery_table_info()
+
     cloud_config = context.get_setting("CLOUD_CONFIG")
     if cloud_config:
         platform_handlers: dict[str, PlatformHandler] = context.get_property(PLATFORM_HANDLERS_PROPERTY_NAME)
         accessed_resource_type_specs: dict[str, list[ResourceTypeSpec]] = context.get_property(RESOURCE_TYPE_SPECS_PROPERTY)
+
+        # FIXME: Debugging code; remove/disable before committing
+        # Current hack to test the checks for premium tables, since currently there aren't
+        # any generation rules that access any premium tables
+        # azure_resource_type_specs = accessed_resource_type_specs.get('azure')
+        # premium_table_resource_spec = ResourceTypeSpec("azure", "azure_monitor_action_groups")
+        # azure_resource_type_specs.append(premium_table_resource_spec)
 
         registry: Registry = context.get_property(REGISTRY_PROPERTY_NAME)
         with tempfile.TemporaryDirectory() as cq_temp_dir:
@@ -219,38 +355,9 @@ def index(context: Context):
                                                                  sqlite_database_file_path,
                                                                  accessed_resource_type_specs)
 
-            common_error_message = "Error running CloudQuery to discover resources"
+            # common_error_message = "Error running CloudQuery to discover resources"
             if len(cq_platform_infos) > 0:
-                # Invoke CloudQuery to scan for resources from all the configured platforms
-                path = os.getenv("PATH")
-                env_vars["PATH"] = path
-                try:
-                    if os.environ.get('DEBUG_LOGGING') == 'true':
-                        process_info = subprocess.run(["cloudquery", "--log-level", "debug", "sync", f"{cq_config_dir}"],
-                                                    capture_output=True,
-                                                    env=env_vars)
-                    else: 
-                        process_info = subprocess.run(["cloudquery", "sync", f"{cq_config_dir}"],
-                                                    capture_output=True,
-                                                    env=env_vars)                        
-                    # Do some debug logging of the info from the CloudQuery run
-                    stderr_text = process_info.stdout.decode('utf-8')
-                    stdout_text = process_info.stderr.decode('utf-8')
-                    logger.debug("Results for subprocess run of cloudquery:")
-                    logger.debug(f"args={process_info.args}")
-                    logger.debug(f"return-code={process_info.returncode}")
-                    logger.debug(f"stderr: {stderr_text}")
-                    logger.debug(f"stdout: {stdout_text}")
-                    # If there was a failure code from CloudQuery, then raise an  exception
-                    if process_info.returncode != 0:
-                        error_message = f"{common_error_message}: " \
-                                        f"return-code={process_info.returncode}; " \
-                                        f"stderr={stderr_text}; " \
-                                        f"stdout={stdout_text}"
-                        raise WorkspaceBuilderException(error_message)
-                except Exception as e:
-                    error_message = f"{common_error_message}; error launching CloudQuery; {str(e)}"
-                    raise WorkspaceBuilderException(error_message) from e
+                invoke_cloudquery("sync", cq_config_dir, env_vars)
 
                 # Convert the tables from the sqlite DB to resources in the resource registry
                 sql_connection = sqlite3.connect(sqlite_database_file_path)

--- a/src/indexers/kubetypes.py
+++ b/src/indexers/kubetypes.py
@@ -65,6 +65,9 @@ class KubernetesResourceTypeSpec(ResourceTypeSpec):
             return False
         return self.group == other.group and self.version == other.version and self.kind == other.kind
 
+    def __hash__(self):
+        return hash((super().__hash__(), self.group, self.version, self.kind))
+
     @staticmethod
     def construct_from_config(config: Union[str, dict[str, Any]]) -> "KubernetesResourceTypeSpec":
         """

--- a/src/map-customization-rules/gcp-project.yaml
+++ b/src/map-customization-rules/gcp-project.yaml
@@ -1,0 +1,11 @@
+apiVersion: runwhen.com/v1
+kind: MapCustomizationRules
+spec:
+  groupRules:
+    - match:
+        type: pattern
+        matchType: base-name
+        pattern: "gcp-function-health"
+        matchMode: substring
+        properties: [name]
+      group: "GCP Project {{project.name}} Resources"

--- a/src/map-customization-rules/namespace-based-rules.yaml
+++ b/src/map-customization-rules/namespace-based-rules.yaml
@@ -94,3 +94,15 @@ spec:
         pattern: "gitops-gh-fix"
         matchMode: substring
       group: "{{namespace.name}} ({{cluster.name}})"
+    - match:
+        type: pattern
+        matchType: base-name
+        pattern: "gitops-gh-fix"
+        matchMode: substring
+      group: "{{namespace.name}} ({{cluster.name}})"
+    - match:
+        type: pattern
+        matchType: base-name
+        pattern: "jaeger-http"
+        matchMode: substring
+      group: "{{namespace.name}} ({{cluster.name}})"

--- a/src/resources.py
+++ b/src/resources.py
@@ -63,7 +63,7 @@ class Platform:
         self.resource_types = dict()
 
 
-@dataclass
+@dataclass(unsafe_hash=True)
 class ResourceTypeSpec:
     """
     Specification of a resource type. This is basically just the combination of the

--- a/src/run.py
+++ b/src/run.py
@@ -474,7 +474,11 @@ def main():
         archive = tarfile.open(fileobj=archive_file_obj, mode="r")
         archive.extractall(output_path)
 
-        print("Workspace data generated successfully.")
+        message = response_data.get("message", "Workspace data generated successfully.")
+        warnings = response_data.get("warnings", list())
+        print(message)
+        for warning in warnings:
+            print("WARNING: " + warning)
 
         # Add cheat-sheet integration, which points at the output items and
         # generates the list of local commands that exist in the TaskSet.

--- a/src/workspace_builder/models.py
+++ b/src/workspace_builder/models.py
@@ -33,10 +33,12 @@ class CommonRunResult:
     Common data for results from the /run endpoint.
     """
     message: str
+    warnings: list[str]
     output_type: str
 
-    def __init__(self, message: str, output_type: str):
+    def __init__(self, message: str, warnings: list[str], output_type: str):
         self.message = message
+        self.warnings = warnings
         self.output_type = output_type
 
 
@@ -47,8 +49,8 @@ class ArchiveRunResult(CommonRunResult):
     """
     output: bytes
 
-    def __init__(self, message: str, output: bytes):
-        super().__init__(message, "archive")
+    def __init__(self, message: str, warnings: list[str], output: bytes):
+        super().__init__(message, warnings, "archive")
         self.output = output
 
 
@@ -59,8 +61,8 @@ class FileItemRunResult(CommonRunResult):
     """
     output: DirectoryItem
 
-    def __init__(self, message: str, output: DirectoryItem):
-        super().__init__(message, "file-items")
+    def __init__(self, message: str, warnings: list[str], output: DirectoryItem):
+        super().__init__(message, warnings, "file-items")
         self.output = output
 
 

--- a/src/workspace_builder/serializers.py
+++ b/src/workspace_builder/serializers.py
@@ -82,6 +82,7 @@ class DirectoryItemSerializer(CommonItemSerializer):
 
 class CommonRunResultSerializer(serializers.Serializer):
     message = serializers.CharField()
+    warnings = serializers.ListField(child=serializers.CharField())
     outputType = serializers.CharField(source="output_type")
 
 

--- a/src/workspace_builder/tests.py
+++ b/src/workspace_builder/tests.py
@@ -48,32 +48,32 @@ BASE_REQUEST_DATA = {
         # },
     ],
     "cloudConfig": {
-    #     "azure": {
-    #         # To enable testing of the cloudquery Azure indexing you need to
-    #         # define the 4 environments variables below either in the shell from
-    #         # which you're running the test or the run configuration in whatever
-    #         # IDE you're using. These environment variables are described in the
-    #         # documentation for the CloudQuery Azure plugin:
-    #         # https://hub.cloudquery.io/plugins/source/cloudquery/azure/v9.3.7/docs
-    #         "subscriptionId": os.getenv("WB_AZURE_SUBSCRIPTION_ID"),
-    #         "tenantId": os.getenv("WB_AZURE_TENANT_ID"),
-    #         "clientId": os.getenv("WB_AZURE_CLIENT_ID"),
-    #         "clientSecret": os.getenv("WB_AZURE_CLIENT_SECRET"),
-    #         "resourceGroupLevelOfDetails": {
-    #             "WorkspaceBuilderTesting": "basic"
-    #         }
-    #     },
+        # "azure": {
+        #     # To enable testing of the cloudquery Azure indexing you need to
+        #     # define the 4 environments variables below either in the shell from
+        #     # which you're running the test or the run configuration in whatever
+        #     # IDE you're using. These environment variables are described in the
+        #     # documentation for the CloudQuery Azure plugin:
+        #     # https://hub.cloudquery.io/plugins/source/cloudquery/azure/v9.3.7/docs
+        #     "subscriptionId": os.getenv("WB_AZURE_SUBSCRIPTION_ID"),
+        #     "tenantId": os.getenv("WB_AZURE_TENANT_ID"),
+        #     "clientId": os.getenv("WB_AZURE_CLIENT_ID"),
+        #     "clientSecret": os.getenv("WB_AZURE_CLIENT_SECRET"),
+        #     "resourceGroupLevelOfDetails": {
+        #         "WorkspaceBuilderTesting": "basic"
+        #     }
+        # },
         "kubernetes": {
             "kubeconfigFile": "kubeconfig",
             "namespaceLODs": {"kube-system": 0, "kube-public": 0},
         }
-    #     "gcp": {
-    #         "applicationCredentialsFile": "GCPServiceAccountKeyWorkspaceBuilder.json",
-    #         "projects": ["iron-radio-408515"],
-    #         "projectLevelOfDetails": {
-    #            "iron-radio-408515": "basic"
-    #         }
-    #     }
+        # "gcp": {
+        #     "applicationCredentialsFile": "GCPServiceAccountKeyWorkspaceBuilder.json",
+        #     "projects": ["iron-radio-408515"],
+        #     "projectLevelOfDetails": {
+        #        "iron-radio-408515": "basic"
+        #     }
+        # }
     }
 }
 
@@ -161,6 +161,10 @@ class ProductionComponentTestCase(TestCase):
             shutil.rmtree(TEST_OUTPUT_DIRECTORY)
         os.makedirs(TEST_OUTPUT_DIRECTORY)
         archive.extractall(TEST_OUTPUT_DIRECTORY)
+        print(response_data.get("message"))
+        warnings = response_data.get("warnings")
+        for warning in warnings:
+            print("WARNING: " + warning)
 
     def test_generation_rules_workspace_gen(self):
         self.run_common("kubeapi,cloudquery,runwhen_default_workspace,generation_rules,render_output_items,dump_resources")

--- a/src/workspace_builder/views.py
+++ b/src/workspace_builder/views.py
@@ -100,7 +100,9 @@ class RunView(APIView):
 
             outputter.close()
             archive_bytes = outputter.get_bytes()
-            run_result = ArchiveRunResult("Run completed successfully. Output saved as archive data.", archive_bytes)
+            run_result = ArchiveRunResult("Workspace builder completed successfully.",
+                                          context.warnings,
+                                          archive_bytes)
         except Exception as e:
             # FIXME: This exception handling block is just for debugging. Can eventually get rid of it.
             next_exc = e


### PR DESCRIPTION
- user can optionally specify a CloudQuery API key in the cloudconfig block in the workspace info. The API key goes inside a nested block named "cloudquery". The field name for the key is "apiKey".
- the API specification is necessary to enable any generation rules that access premium tables.
- the cloudquery CLI errors out if any source plugin is configured to access a premium table and no API key is specified, so there's new code that uses the "cloudquery tables" command to get the metadata about the tables for the plugin, which includes whether or not the table is a paid/premium table. This information is used for the cloudquery sync operation to suppress the inclusion of any premium tables that are accessed by gen rules in the case where no API key is specified. In that case a warning message is logged indicating that the table was omitted from the CloudQuery config and that they need to provide an API key to enable that table.
- ideally the warning message would also include info about which generation rule / code bundle was being disabled because of the access to a premium table, but unfortunately the current data structures for the accessed resource types / tables does not include the binding to the generation rule(s) that use them, so we can't do that for now. I'll fix that as a separate task.
- refactored and cleaned up the code that invokes the cloudquery CLI since it's not being called separately for the "sync" and "tables" commands.