### PR TITLE
Fix/cq-proxy

### DIFF
--- a/src/VERSION
+++ b/src/VERSION
@@ -1,4 +1,4 @@
 {
   "name":    "runwhen-local",
-  "version": "0.5.2"
+  "version": "0.5.3"
 }

--- a/src/indexers/cloudquery.py
+++ b/src/indexers/cloudquery.py
@@ -112,6 +112,15 @@ def invoke_cloudquery(cq_command: str,
     # We need to set the PATH environment variable so that the cloudquery CLI can be found
     path = os.getenv("PATH")
     cq_env_vars["PATH"] = path
+    
+    # Check if HTTP_PROXY and HTTPS_PROXY are set in the OS environment and add them if they are
+    http_proxy = os.getenv("HTTP_PROXY")
+    https_proxy = os.getenv("HTTPS_PROXY")
+    if http_proxy:
+        cq_env_vars["HTTP_PROXY"] = http_proxy
+    if https_proxy:
+        cq_env_vars["HTTPS_PROXY"] = https_proxy
+
     common_error_message = "Error running CloudQuery to discover resources"
     try:
         # Construct the args to use to invoke the CloudQuery CLI

--- a/src/run.sh
+++ b/src/run.sh
@@ -1,10 +1,15 @@
-#!/bin/sh
+#!/bin/bash
 
 # Path to the lock file
 LOCK_FILE="/workspace-builder/.wb_lock"
+DISABLE_CLOUDQUERY=0
 
-if [ "$1" = "-h" -o "$1" = "--help" ]; then
-  echo """Usage: `basename $0` [-w WORKSPACE_INFO_FILE] [-k KUBECONFIG_FILE] [-r CUSTOMIZATION_RULES_FILE] [-o OUTPUT_DIRECTORY]
+# Parse arguments
+POSITIONAL_ARGS=()
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    -h|--help)
+      echo """Usage: $(basename $0) [-w WORKSPACE_INFO_FILE] [-k KUBECONFIG_FILE] [-r CUSTOMIZATION_RULES_FILE] [-o OUTPUT_DIRECTORY] [--disable-cloudquery]
 Optional arguments:
   -h, --help
       Display help about running the command and exit
@@ -19,10 +24,22 @@ Optional arguments:
   --upload
       Upload the generated workspace content to the PAPI server specified in the workspace info file.
   -v, --verbose
-      Print more detailed output."""
-
-  exit 0
-fi
+      Print more detailed output.
+  --disable-cloudquery
+      Disable the cloudquery component."""
+      exit 0
+      ;;
+    --disable-cloudquery)
+      DISABLE_CLOUDQUERY=1
+      shift # past argument
+      ;;
+    *)    # unknown option
+      POSITIONAL_ARGS+=("$1") # save it in an array for later
+      shift # past argument
+      ;;
+  esac
+done
+set -- "${POSITIONAL_ARGS[@]}" # restore positional parameters
 
 # Check if the lock file exists and exit if it's locked
 if [ -e "$LOCK_FILE" ]; then
@@ -34,8 +51,14 @@ fi
 # Create the lock file
 touch "$LOCK_FILE"
 
+# Construct components string based on whether --disable-cloudquery is set
+COMPONENTS="kubeapi,runwhen_default_workspace,generation_rules,render_output_items,dump_resources"
+if [ $DISABLE_CLOUDQUERY -eq 0 ]; then
+    COMPONENTS="kubeapi,cloudquery,runwhen_default_workspace,generation_rules,render_output_items,dump_resources"
+fi
+
 # Run the Python script with your specified arguments
-python3 run.py run --components "kubeapi,cloudquery,runwhen_default_workspace,generation_rules,render_output_items,dump_resources" $@
+python3 run.py run --components "$COMPONENTS" $@
 
 # Remove the lock file after the Python script exits
 rm -f "$LOCK_FILE"


### PR DESCRIPTION
Passes proxy environments to cloudquery subprocess in support of https://github.com/runwhen-contrib/runwhen-local/issues/443
Also adds the ability to disable cloudquery in the run.sh command with `--disable-cloudquery` - mostly focused for teams only discoverying Kubernetes resources and not requiring any other public cloud discovery. 