### PR TITLE
test permission edits

### DIFF
--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -131,13 +131,32 @@ RUN mkdir $RUNWHEN_SHARED \
 RUN apt-get update && apt-get install -y nginx && apt-get clean && rm -rf /var/lib/apt/lists/*
 COPY nginx.conf /etc/nginx/sites-enabled/default
 
-# Set ownership for Nginx directories and files
-RUN chown -R runwhen:runwhen /etc/nginx/ \
-    && chown -R runwhen:runwhen /var/log/nginx/ \
-    && chown -R runwhen:runwhen /usr/share/nginx/html \
-    && touch /run/nginx.pid \
-    && chown runwhen:runwhen /run/nginx.pid \
-    && chown -R runwhen:runwhen /var/lib/nginx/
+
+# Adjust ownership and permissions for Nginx directories and files to ensure compatibility with arbitrary user IDs
+RUN mkdir -p /var/log/nginx /var/lib/nginx /run/nginx /usr/share/nginx/html && \
+    chown -R :0 /etc/nginx /var/log/nginx /usr/share/nginx/html /var/lib/nginx && \
+    chmod -R g+rwX /etc/nginx /var/log/nginx /usr/share/nginx/html /var/lib/nginx && \
+    touch /run/nginx.pid && \
+    chown :0 /run/nginx.pid && \
+    chmod g+rwX /run/nginx.pid && \
+    find /etc/nginx /var/log/nginx /usr/share/nginx/html /var/lib/nginx -type d -exec chmod g+s {} \+
+
+
+# # Set ownership for Nginx directories and files
+# RUN chown -R runwhen:0 /etc/nginx/ \
+#     && chown -R runwhen:0 /var/log/nginx/ \
+#     && chown -R runwhen:0 /usr/share/nginx/html \
+#     && touch /run/nginx.pid \
+#     && chown runwhen:0 /run/nginx.pid \
+#     && chown -R runwhen:0 /var/lib/nginx/
+
+# # Set ownership for Nginx directories and files
+# RUN chown -R runwhen:runwhen /etc/nginx/ \
+#     && chown -R runwhen:runwhen /var/log/nginx/ \
+#     && chown -R runwhen:runwhen /usr/share/nginx/html \
+#     && touch /run/nginx.pid \
+#     && chown runwhen:runwhen /run/nginx.pid \
+#     && chown -R runwhen:runwhen /var/lib/nginx/
 
 
 USER runwhen


### PR DESCRIPTION
Adjust permissions to support non runwhen user, such as the default user and random id assigned from openshift. 

Should resolve https://github.com/runwhen-contrib/runwhen-local/issues/447