### PR TITLE
Initial AWS support

### DIFF
--- a/src/enrichers/aws.py
+++ b/src/enrichers/aws.py
@@ -1,0 +1,169 @@
+from typing import Any, Optional
+
+from component import Context
+from resources import Resource, Registry, REGISTRY_PROPERTY_NAME
+from .generation_rule_types import PlatformHandler, LevelOfDetail
+from exceptions import WorkspaceBuilderException
+AWS_PLATFORM = "aws"
+
+def get_resource_group(resource: Resource) -> Optional[Resource]:
+    # FIXME: Shouldn't use hard-coded string here
+    if resource.resource_type.name == "resource_group":
+        return resource
+    try:
+        return getattr(resource, "resource_group")
+    except AttributeError:
+        return None
+
+class ARN:
+    partition: str
+    service: str
+    region: str
+    account: str
+    resource_type: str
+    resource_id: str
+
+    def __init__(self, arn_string):
+        parts = arn_string.split(':', 5)
+        self.partition = parts[1]
+        self.service = parts[2]
+        self.region = parts[3]
+        self.account = parts[4]
+        resource_info = parts[5]
+        # Annoyingly different resource type can use either a ':' or a '/' as the
+        # separator between the resource type and id fields, so we try both.
+        resource_parts = resource_info.split(':', 1)
+        if len(resource_parts) < 2:
+            resource_parts = resource_info.split('/', 1)
+        self.resource_type = resource_parts[0] if len(resource_parts) > 0 else None
+        self.resource_id = resource_parts[1] if len(resource_parts) > 1 else None
+
+class AWSPlatformHandler(PlatformHandler):
+
+    def __init__(self):
+        super().__init__(AWS_PLATFORM)
+
+    def parse_resource_data(self,
+                            resource_data: dict[str,Any],
+                            resource_type_name: str,
+                            platform_config_data: dict[str,Any],
+                            context: Context) -> tuple[str, str, dict[str, Any]]:
+        # From testing even with a limited number of AWS resource types, there's not a consistent
+        # name in the resource data for the name/id of the resource. For example for a resource group
+        # it's called "name", but for an EC2 instance it's called instance_id. But it does seem like
+        # all the resources (I think?) will have an "arn" field that we can parse to extract the name/id
+        # value, so that's how we handle this. From googling around a bit it seems like there are some
+        # informal guarantees that the name/id is unique, even across regions, although I'm somewhat
+        # dubious of that, but I'll assume that's true at least for now. What this means is that we
+        # can just use the simple name/id as the qualified name without qualifying it with any other
+        # info. If this turns out to not be true, then we could scope if with the region or possibly
+        # just use the ARN value directly as the qualified name.
+        arn_string = resource_data['arn']
+        arn = ARN(arn_string)
+        name = arn.resource_id
+        qualified_name = name
+        tags = resource_data.get('tags', dict())
+        resource_attributes = {'tags': tags}
+
+        # Since the resource group support that I tried to get working doesn't seem to work with
+        # CloudQuery, I'm just going to support a per-resource mechanism for tagging with the
+        # LOD value. Note that this is a something that's been requested as a feature across all
+        # the indexers, so I should also get it working for the other cloud platforms, but for
+        # now it's only supported on AWS.
+        for tag_key, tag_value in tags.items():
+            if tag_key.lower() in ('lod', 'levelofdetail', 'level-of-detail'):
+                try:
+                    lod = LevelOfDetail.construct_from_config(tag_value)
+                    break
+                except WorkspaceBuilderException:
+                    pass
+        else:
+            lod = context.get_setting("DEFAULT_LOD")
+        resource_attributes['lod'] = lod
+
+        # FIXME: Disabling all of this resource-group-specific code until I figure out if
+        # there's a way to actually support. It doesn't appear to be possible with what you
+        # get from CloudQuery and would presumably require a separate call to the native
+        # AWS python library to resolve the resource instance members of the resource group.
+        # if resource_type_name == "resource_group":
+        #     # Set the 'lod' (level-of-detail) resource attribute from the per-resource-group
+        #     # setting in the AWS cloud config or set to the default value if it's unspecified
+        #     # FIXME: It's a big kludgy to have the level of detail setting in the resource,
+        #     # since that's really a generation rules feature, not an indexing feature.
+        #     # Although we do currently use it in kubeapi to optimize the indexing to skip indexing
+        #     # namespaces whose level-of-detail is "none". But I still think it would be
+        #     # cleaner to not have any LOD setting logic in the indexers and just use it
+        #     # internally in the generation rules module. There could be some other mechanism
+        #     # to disable indexing for particular namespaces / resource groups in the indexers.
+        #     # In any case, we want to skip the else logic here that tries to extract
+        #     # the parent resource group of the resource since that doesn't make sense
+        #     # for the resource group itself (unless Azure supports nested resource
+        #     # groups? but I don't think it does).
+        #     resource_group_level_of_detail_config = platform_config_data.get("resourceGroupLevelOfDetails", dict())
+        #     resource_group_lod_value = resource_group_level_of_detail_config.get(name)
+        #     # FIXME: Not great maintainance-wise to lookup setting values by the setting name here.
+        #     # Would be better to lookup by the actual Setting class singleton (which is not supported
+        #     # by the get_setting method). Unfortunately, currently, if we try to use the default LOD
+        #     # setting it leads to a module import circularity, so some cleanup/refactoring of
+        #     # where the settings are defined is needed to get that to work. So for the time being
+        #     # we still use the hard-coded name :-(
+        #     resource_attributes['lod'] = LevelOfDetail.construct_from_config(resource_group_lod_value) \
+        #         if resource_group_lod_value is not None else context.get_setting("DEFAULT_LOD")
+        # else:
+        #     resource_group_name = resource_data.get("resourceGroup")
+        #     if resource_group_name:
+        #         # Lookup the associated resource group instance from the resource registry
+        #         registry: Registry = context.get_property(REGISTRY_PROPERTY_NAME)
+        #         resource_group_resource_type = registry.lookup_resource_type(AWS_PLATFORM, "resource_group")
+        #         if resource_group_resource_type:
+        #             for resource_group in resource_group_resource_type.instances.values():
+        #                 if resource_group.name.upper() == resource_group_name.upper():
+        #                     resource_attributes['resource_group'] = resource_group
+        #                     break
+        #         qualified_name = f"{resource_group_name}/{name}"
+
+        return name, qualified_name, resource_attributes
+
+    def get_level_of_detail(self, resource: Resource) -> Optional[LevelOfDetail]:
+        # resource_group = get_resource_group(resource)
+        # if not resource_group:
+        #     return None
+        # level_of_detail = getattr(resource_group, 'lod')
+        level_of_detail = getattr(resource, 'lod')
+        return level_of_detail
+
+    # @staticmethod
+    # def get_common_resource_property_values(resource: Resource, qualifier_name: str) -> Optional[str]:
+    #     if qualifier_name == "resource_group":
+    #         return get_resource_group(resource).name
+    #     else:
+    #         # FIXME: Should we treat this as an error, i.e. raise Exception?
+    #         return None
+    #
+    # def get_resource_qualifier_value(self, resource: Resource, qualifier_name: str) -> Optional[str]:
+    #     return self.get_common_resource_property_values(resource, qualifier_name)
+
+    def get_resource_property_values(self, resource: Resource, property_name: str) -> Optional[list[Any]]:
+        property_name = property_name.lower()
+        tags = getattr(resource, "tags")
+        if property_name == "tags":
+            return list(tags.keys()) + list(tags.values())
+        elif property_name == "tag-keys":
+            return list(tags.keys())
+        elif property_name == "tag-values":
+            return list(tags.values())
+        else:
+            # Note, the property value may be a path within the
+            return None
+
+    # def get_standard_template_variables(self, resource: Resource) -> dict[str, Any]:
+    #     template_variables = dict()
+    #     resource_group = get_resource_group(resource)
+    #     if resource_group:
+    #         template_variables['resource_group'] = resource_group
+    #     return template_variables
+    #
+    # def resolve_template_variable_value(self, resource: Resource, variable_name: str) -> Optional[Any]:
+    #     return self.get_common_resource_property_values(resource, variable_name)
+
+

--- a/src/enrichers/generation_rule_types.py
+++ b/src/enrichers/generation_rule_types.py
@@ -34,6 +34,13 @@ class LevelOfDetail(Enum):
                 return LevelOfDetail[config.upper()]
         except (ValueError, KeyError):
             pass
+        # FIXME: I think this should probably be a WorkspaceBuilderUserException, since
+        # this would most likely be the result of someone using an incorrect value in
+        # their workspace info data and thus would be user error. I guess it could also
+        # come from a value in a gen rule for a code bundle, but presumably that should
+        # get caught by the code bundle author and not be something that normal end
+        # users would see. But, anyway, I need to think about it some more and would
+        # need more testing for regressions, although I think it would just work.
         raise WorkspaceBuilderException(f"Invalid level of detail value: {config}")
 
 # FIXME: It feels a bit kludgy to me to do the LevelOfDetail YAML serialization/deserialization

--- a/src/enrichers/generation_rules.py
+++ b/src/enrichers/generation_rules.py
@@ -26,6 +26,8 @@ from .generation_rule_types import (
 from .kubernetes import KubernetesPlatformHandler
 from .azure import AzurePlatformHandler, AZURE_PLATFORM
 from .gcp import GCPPlatformHandler, GCP_PLATFORM
+from .aws import AWSPlatformHandler, AWS_PLATFORM
+
 from renderers.render_output_items import OUTPUT_ITEMS_PROPERTY
 from renderers.render_output_items import OutputItem as RendererOutputItem
 from resources import (
@@ -833,6 +835,7 @@ def load(context: Context) -> None:
         KUBERNETES_PLATFORM: KubernetesPlatformHandler(),
         AZURE_PLATFORM: AzurePlatformHandler(),
         GCP_PLATFORM: GCPPlatformHandler(),
+        AWS_PLATFORM: AWSPlatformHandler(),
     }
     context.set_property(PLATFORM_HANDLERS_PROPERTY_NAME, platform_handlers)
     request_code_collections = context.get_setting("CODE_COLLECTIONS")

--- a/src/indexers/cloudquery_templates/aws-config.yaml
+++ b/src/indexers/cloudquery_templates/aws-config.yaml
@@ -1,0 +1,32 @@
+kind: source
+spec:
+  # Source spec section
+  name: aws
+  path: cloudquery/aws
+  registry: cloudquery
+  version: "v24.3.3"
+  destinations: ["{{destination_plugin_name}}"]
+  tables: [
+    {% for table_name in tables %}
+    "{{table_name}}",
+    {% endfor %}
+  ]
+  spec:
+    # Optional parameters
+    # regions: []
+    # accounts: []
+    # org: nil
+    # concurrency: 50000
+    # initialization_concurrency: 4
+    # aws_debug: false
+    # max_retries: 10
+    # max_backoff: 30
+    # custom_endpoint_url: ""
+    # custom_endpoint_hostname_immutable: nil # required when custom_endpoint_url is set
+    # custom_endpoint_partition_id: "" # required when custom_endpoint_url is set
+    # custom_endpoint_signing_region: "" # required when custom_endpoint_url is set
+    # use_paid_apis: false
+    # table_options: nil
+    # scheduler: shuffle # options are: dfs, round-robin or shuffle
+    # use_nested_table_rate_limiting: false
+    # enable_api_level_tracing: false


### PR DESCRIPTION
- auth configuration for AWS is done in a similar way to the other cloud platforms. There's an "aws" block in the "cloudConfig" section of the workspace info that contains the AWS-specific info. Currently, this is just the auth information. Auth is done via an AWS access key. The fields are awsAccessKeyId & awsSecretAccessKey, which map to the similarly-named fields described in the CloudQuery documentation for the AWS plugin. There's also a field for a session token named awsSessionToken, which I included to mirror what's described in the CQ documentation, but I didn't figure out how to use that, so it's untested at this point.
- I experimented with using AWS resource groups as a grouping mechanism similar to the namespace/project/resource-group scoping mechanisms in the other cloud platforms. But the AWS resource group is more of a dynamic mechanism that evaluates a matching function based on the tags that are assigned to the resources. This requires an additional AWS API call to evaluate that query that it doesn't seem like CloudQuery currently supports, so I wasn't able to get that to work. I left the code in there (but disabled/commented-out), though, for now just in case there's something I'm missing about how to enable it for CQ.
- Since there's no grouping mechanism, it wasn't obvious how to handle level of detail assignment, since for all of the other platforms that's handled by mapping the resources to their parent scope and then assigned the LOD value at that scope. So what I did for AWS was to support an LOD tagging mechanism on the resources in AWS. It will check for a tag named any "lod", "LevelOfDetail" or "level-of-detail" whose value is the usual supported LOD values.
- note that this LOD tagging feature for AWS is similar to a generic LOD tagging feature that's been requested and I plan to work on soon, but for now this is an AWS-only feature.
- there possibly should be a workspaceInfo-based way to specify the LOD values for resources, but this would be more complicated then how it's done for the other cloud platforms, since there wouldn't be a common resource type where it's specified, so the spec would need to encode the resource type and id. This is doable, but I need to think some more about exactly how it would work.