### PR TITLE
Fix/cloudconfig-in-cluster-auth

### DIFF
--- a/src/VERSION
+++ b/src/VERSION
@@ -1,4 +1,4 @@
 {
   "name":    "runwhen-local",
-  "version": "0.5.7"
+  "version": "0.5.8"
 }


### PR DESCRIPTION
the feature to generate an in-cluster-auth config didn't function when workspaceInfo references cloudConfig for kubernetes provider information - this shuffles the code around to create a /shared/kubeconfig file from the in-cluster-auth if the file doesn't already exist. 