### PR TITLE
Option to prune stale SLXs on upload to the platform

### DIFF
--- a/src/run.py
+++ b/src/run.py
@@ -185,6 +185,9 @@ def main():
                         help='On upload, how to merge conflicting SLXs; valid values are:\n'
                              '  "keep-existing": Use the existing content of the SLX from the repo\n'
                              '  "keep-uploaded": Use the uploaded content of the SLX')
+    parser.add_argument('--prune-stale-slxs', action='store_true', dest='prune_stale_slxs', default=False,
+                        help='On upload, prune from the repo any old/stale SLXs from previous uploads that\n'
+                             'are no longer active/valid in the current uploaded data.')
     parser.add_argument('-r', '--customization-rules', action='store', dest='customization_rules',
                         default=CUSTOMIZATION_RULES_DEFAULT,
                         help="Path to location of map customization rules file(s). The path "
@@ -562,6 +565,7 @@ def main():
         upload_request_data = {
             "output": archive_text,
             "mergeMode": merge_mode,
+            "pruneStaleSlxs": args.prune_stale_slxs,
             "message": "Updated workspace from map builder.",
             "finalizeAction": "mergeToMain",
         }


### PR DESCRIPTION
Specify the --prune-stale-slsx flag when executing the workspace builder to enable this upload mode. If enabled, then any SLXs in the existing repo that were originally generated by the workspace builder but are not present in the new upload data are pruned from the repo. SLXs that were manually created/configured by the user are never pruned.