### PR TITLE
update slx name with unique hash and add qualifiers to annotations

### DIFF
--- a/src/VERSION
+++ b/src/VERSION
@@ -1,4 +1,4 @@
 {
   "name":    "runwhen-local",
-  "version": "0.5.22"
+  "version": "0.6.0"
 }

--- a/src/enrichers/generation_rules.py
+++ b/src/enrichers/generation_rules.py
@@ -613,6 +613,12 @@ def get_template_variables(output_item: OutputItem,
             value = render_template_string(template_string, template_variables)
         template_variables[name] = value
 
+    # Add qualifiers to template variables
+    if 'qualifiers' in output_item.template_variables:
+        qualifiers_dict = {qual: template_variables[qual] for qual in output_item.template_variables['qualifiers']}
+        template_variables['qualifiers'] = qualifiers_dict
+
+
     return template_variables
 
 
@@ -760,7 +766,10 @@ def generate_slx_output_items(slx_info: SLXInfo,
     slx_directory_path = os.path.join(slxs_path, slx_info.qualified_name)
     slx_base_template_variables['slx_directory_path'] = slx_directory_path
     slx_base_template_variables['match_resource'] = resource
-
+    # Convert qualifiers list to a dictionary of key/value pairs
+    qualifiers_dict = {qual: slx_info.qualifier_values[i] for i, qual in enumerate(slx_info.slx.qualifiers)}
+    slx_base_template_variables['qualifiers'] = qualifiers_dict
+    
     for output_item in slx_info.slx.output_items:
         if should_emit_output_item(output_item, slx_info.level_of_detail):
             generate_output_item(generation_rule_info,

--- a/src/name_utils.py
+++ b/src/name_utils.py
@@ -1,8 +1,13 @@
 import re
-
+import hashlib
 
 def split_camel_cased_name(name: str) -> list[str]:
-    result = list()
+    """
+    Splits a camel-cased name into its constituent parts.
+    :param name: The camel-cased name.
+    :return: A list of name parts.
+    """
+    result = []
     pending_part = ""
     for c in name:
         if c.isupper():
@@ -16,31 +21,37 @@ def split_camel_cased_name(name: str) -> list[str]:
     return result
 
 def sanitize_name(name: str) -> str:
-    """ Remove or replace characters that are unsuitable for file names. """
+    """
+    Remove or replace characters that are unsuitable for file names.
+    :param name: The name to sanitize.
+    :return: The sanitized name.
+    """
     return name.replace(':', '-').replace('/', '-')
 
 def remove_vowels(name: str, keep_first_letter: bool) -> str:
+    """
+    Remove vowels from a name, optionally keeping the first letter.
+    :param name: The name to process.
+    :param keep_first_letter: Whether to keep the first letter.
+    :return: The name with vowels removed.
+    """
     kept_letters = [name[i] for i in range(len(name)) if ((i == 0) and keep_first_letter) or (name[i] not in "aeiou")]
     return ''.join(kept_letters)
 
 def shorten_name(name: str, max_chars: int = 3, separator=None) -> str:
+    """
+    Shorten a name to a specified maximum number of characters.
+    :param name: The name to shorten.
+    :param max_chars: The maximum number of characters.
+    :param separator: Optional separator to use between parts.
+    :return: The shortened name.
+    """
     if len(name) <= max_chars:
         return name
-    # First split on the allowed punctuation characters
-    # For now this is hard-coded to the allowed non-alphanumeric characters
-    # in Kubernetes names.
-    # TODO: Eventually would probably be nice to have an input argument
-    # to customize the set of punctuation delimiters
     punctuated_parts = re.split(r"[_\-.]", name)
-    parts = list()
+    parts = []
     for punctuated_part in punctuated_parts:
         parts += split_camel_cased_name(punctuated_part)
-    # If no explicit separator is given, then first try it with dashes and see if we
-    # can use more than 1 character per part. If so, then use the dash. If not, then
-    # set it to use spaces. The rationale is that if we can only fit 1 character per
-    # part then it would look weird to hyphenate all the single characters, and instead
-    # it would look better to just one big initialism. Not completely sure this makes
-    # the most sense, but we can iterate this based on real-world examples.
     parts = [remove_vowels(part, True) for part in parts]
     if separator is None:
         separator = '-' if len(parts) * 2 < max_chars else ''
@@ -49,12 +60,31 @@ def shorten_name(name: str, max_chars: int = 3, separator=None) -> str:
     tiny_name = separator.join(first_letters)
     return tiny_name
 
+def generate_hash(qualifiers: list[str]) -> str:
+    """
+    Generate a consistent hash for the qualifiers.
+    :param qualifiers: The list of qualifiers.
+    :return: The first 8 characters of the SHA-1 hash of the combined qualifiers.
+    """
+    combined_qualifiers = '-'.join(qualifiers)
+    hash_object = hashlib.sha1(combined_qualifiers.encode())
+    return hash_object.hexdigest()[:8]  # Use the first 8 characters of the hash for brevity
 
 def make_slx_name(workspace_name: str, qualified_slx_name: str) -> str:
-    """ Ensure the slx name is safe for file naming. """
+    """
+    Ensure the SLX name is safe for file naming and fits within the Kubernetes name limit.
+    :param workspace_name: The workspace name.
+    :param qualified_slx_name: The qualified SLX name.
+    :return: The combined and sanitized SLX name.
+    """
+    max_k8s_name_length = 63
+    combined_length = len(workspace_name) + 2 + len(qualified_slx_name)  # 2 for the "--" separator
+    if combined_length > max_k8s_name_length:
+        # Truncate the qualified SLX name if necessary
+        excess_length = combined_length - max_k8s_name_length
+        qualified_slx_name = qualified_slx_name[:-excess_length]
     safe_qualified_slx_name = sanitize_name(qualified_slx_name)
     return f"{workspace_name}--{safe_qualified_slx_name}"
-
 
 def make_qualified_slx_name(base_name: str, qualifiers: list[str], max_length=23) -> str:
     """
@@ -66,10 +96,10 @@ def make_qualified_slx_name(base_name: str, qualifiers: list[str], max_length=23
     length of the name. Hopefully in the future we'll handle this differently
     such that we don't need to do these name shortening tricks to fix into
     64 characters.
-    :param base_name:
-    :param qualifiers:
-    :param max_length:
-    :return:
+    :param base_name: The base name of the SLX.
+    :param qualifiers: The list of qualifiers.
+    :param max_length: The maximum length of the qualified SLX name.
+    :return: The sanitized and shortened qualified SLX name.
     """
     if not max_length:
         max_length = 1000000
@@ -77,11 +107,10 @@ def make_qualified_slx_name(base_name: str, qualifiers: list[str], max_length=23
     if arg_count == 0:
         return sanitize_name(base_name)
 
-    # The minus 1 at the end is to account for the dash between the
-    # qualifiers/args and the base name suffix.
-    remaining_length = max_length - len(base_name) - 1
+    remaining_length = max_length - len(base_name) - 1 - 9  # Reserve 9 characters for hash and separator
     chars_per_arg = (remaining_length - (arg_count - 1)) // arg_count
     shortened_args = [shorten_name(qualifiers[i].replace('_', '-'), chars_per_arg) for i in range(len(qualifiers))]
     args_string = '-'.join(shortened_args)
-    qualified_slx_name = f"{args_string}-{base_name}"
+    hash_suffix = generate_hash(qualifiers)
+    qualified_slx_name = f"{args_string}-{base_name}-{hash_suffix}"
     return sanitize_name(qualified_slx_name)

--- a/src/templates/common-annotations.yaml
+++ b/src/templates/common-annotations.yaml
@@ -3,4 +3,6 @@
     sourceGenerationRuleRepoRef: {{ref}}
     sourceGenerationRulePath: {{generation_rule_file_path}}
     config.runwhen.com/last-updated-by: workspace-builder
+    qualifiers: {{qualifiers}}
+
 

--- a/src/templates/common-annotations.yaml
+++ b/src/templates/common-annotations.yaml
@@ -3,6 +3,6 @@
     sourceGenerationRuleRepoRef: {{ref}}
     sourceGenerationRulePath: {{generation_rule_file_path}}
     config.runwhen.com/last-updated-by: workspace-builder
-    qualifiers: {{qualifiers}}
+    qualifiers: "{{qualifiers}}"
 
 


### PR DESCRIPTION
This PR version bumps to 0.6.0, as it changes the SLX names to add a unique hash in an effort to reduce upload conflicts. This mostly affects any user that uses RunWhen Local to reconcile their RunWhen Platform Workspace. It requires that the workspace SLXs be reset, as the next upload will create entirely new SLXs. 