### PR TITLE
Fix/aks-explicit

### DIFF
--- a/.test/azure/multi-subscription-aks/Taskfile.yaml
+++ b/.test/azure/multi-subscription-aks/Taskfile.yaml
@@ -89,6 +89,9 @@ tasks:
         # - repoURL: "$repo_url"
         #   branch: "$branch_name"
         #   codeBundles: ["$codebundle"]
+        custom: 
+          azure_service_principal_secret_name: azure-sp
+          kubernetes_distribution_binary: kubectl
         EOF
     silent: true
 

--- a/.test/azure/multi-subscription-aks/Taskfile.yaml
+++ b/.test/azure/multi-subscription-aks/Taskfile.yaml
@@ -85,7 +85,11 @@ tasks:
               resourceGroupLevelOfDetails:
                 $cluster1_resource_group: detailed
                 $cluster2_resource_group: detailed
-        codeCollections: []
+        codeCollections: 
+          - repoURL: "https://github.com/stewartshea/rw-cli-codecollection"
+            branch: "azure/add_sub_vars"
+            codeBundles: ["k8s-namespace-healthcheck", "azure-aks-triage"]
+        # codeCollections: []
         # - repoURL: "$repo_url"
         #   branch: "$branch_name"
         #   codeBundles: ["$codebundle"]

--- a/.test/azure/multi-subscription-aks/terraform/main.tf
+++ b/.test/azure/multi-subscription-aks/terraform/main.tf
@@ -99,13 +99,13 @@ resource "azurerm_role_assignment" "cluster_2_sp_owner" {
 }
 
 # Role Assignment for Service Principal
-# resource "azurerm_role_assignment" "cluster_2_sp_reader" {
-#  provider            = azurerm.cluster_1
-#  scope               = "/subscriptions/${var.subscription_id_2}"
-#  role_definition_name = "Reader"
-#  principal_id        = var.sp_principal_id
-#  principal_type      = "ServicePrincipal"
-# }
+resource "azurerm_role_assignment" "cluster_2_sp_reader" {
+  provider             = azurerm.cluster_1
+  scope                = "/subscriptions/${var.subscription_id_2}"
+  role_definition_name = "Reader"
+  principal_id         = var.sp_principal_id
+  principal_type       = "ServicePrincipal"
+}
 
 # AKS Cluster
 resource "azurerm_kubernetes_cluster" "cluster_2_aks" {

--- a/.test/azure/multi-subscription-aks/terraform/main.tf
+++ b/.test/azure/multi-subscription-aks/terraform/main.tf
@@ -5,7 +5,7 @@ resource "azurerm_resource_group" "cluster_1_rg" {
   provider = azurerm.cluster_1
   name     = "azure-aks-1"
   location = "East US"
-  tags     = {
+  tags = {
     "env"       = "test"
     "lifecycle" = "deleteme"
     "product"   = "runwhen"
@@ -22,19 +22,19 @@ resource "azurerm_user_assigned_identity" "cluster_1_identity" {
 
 # Role Assignment for Service Principal
 resource "azurerm_role_assignment" "cluster_1_sp_owner" {
-  provider            = azurerm.cluster_1
-  scope               = "/subscriptions/${var.subscription_id_1}"
+  provider             = azurerm.cluster_1
+  scope                = "/subscriptions/${var.subscription_id_1}"
   role_definition_name = "Azure Kubernetes Service RBAC Cluster Admin"
-  principal_id        = var.sp_principal_id
-  principal_type      = "ServicePrincipal"
+  principal_id         = var.sp_principal_id
+  principal_type       = "ServicePrincipal"
 }
 # Role Assignment for Service Principal
 resource "azurerm_role_assignment" "cluster_1_sp_reader" {
-  provider            = azurerm.cluster_1
-  scope               = "/subscriptions/${var.subscription_id_1}"
+  provider             = azurerm.cluster_1
+  scope                = "/subscriptions/${var.subscription_id_1}"
   role_definition_name = "Reader"
-  principal_id        = var.sp_principal_id
-  principal_type      = "ServicePrincipal"
+  principal_id         = var.sp_principal_id
+  principal_type       = "ServicePrincipal"
 }
 # AKS Cluster
 resource "azurerm_kubernetes_cluster" "cluster_1_aks" {
@@ -74,7 +74,7 @@ resource "azurerm_resource_group" "cluster_2_rg" {
   provider = azurerm.cluster_2
   name     = "azure-aks-2"
   location = "West US"
-  tags     = {
+  tags = {
     "env"       = "test"
     "lifecycle" = "deleteme"
     "product"   = "runwhen"
@@ -91,21 +91,21 @@ resource "azurerm_user_assigned_identity" "cluster_2_identity" {
 
 # Role Assignment for Service Principal
 resource "azurerm_role_assignment" "cluster_2_sp_owner" {
-  provider            = azurerm.cluster_2
-  scope               = "/subscriptions/${var.subscription_id_2}"
+  provider             = azurerm.cluster_2
+  scope                = "/subscriptions/${var.subscription_id_2}"
   role_definition_name = "Azure Kubernetes Service RBAC Cluster Admin"
-  principal_id        = var.sp_principal_id
-  principal_type      = "ServicePrincipal"
+  principal_id         = var.sp_principal_id
+  principal_type       = "ServicePrincipal"
 }
 
 # Role Assignment for Service Principal
-resource "azurerm_role_assignment" "cluster_2_sp_reader" {
-  provider            = azurerm.cluster_1
-  scope               = "/subscriptions/${var.subscription_id_2}"
-  role_definition_name = "Reader"
-  principal_id        = var.sp_principal_id
-  principal_type      = "ServicePrincipal"
-}
+# resource "azurerm_role_assignment" "cluster_2_sp_reader" {
+#  provider            = azurerm.cluster_1
+#  scope               = "/subscriptions/${var.subscription_id_2}"
+#  role_definition_name = "Reader"
+#  principal_id        = var.sp_principal_id
+#  principal_type      = "ServicePrincipal"
+# }
 
 # AKS Cluster
 resource "azurerm_kubernetes_cluster" "cluster_2_aks" {

--- a/src/VERSION
+++ b/src/VERSION
@@ -1,4 +1,4 @@
 {
   "name":    "runwhen-local",
-  "version": "0.7.5"
+  "version": "0.7.6"
 }

--- a/src/azure_utils.py
+++ b/src/azure_utils.py
@@ -145,6 +145,23 @@ def generate_kubeconfig_for_aks(clusters, workspace_info):
                     for cluster_entry in kubeconfig_yaml['clusters']:
                         cluster_entry['cluster']['server'] = server_url
 
+                # Add resource_group to the "workspace-builder" extension
+                logger.info(f"Adding resource_group to workspace-builder extension for cluster: {cluster_name}")
+                for cluster_entry in kubeconfig_yaml['clusters']:
+                    if 'extensions' not in cluster_entry['cluster']:
+                        cluster_entry['cluster']['extensions'] = []
+
+                    cluster_entry['cluster']['extensions'].append({
+                        'name': 'workspace-builder',
+                        'extension': {
+                            'resource_group': resource_group_name,
+                            'cluster_type': 'aks',
+                            'cluster_name': cluster_name,
+                            'auth_type': auth_type,
+                            'auth_secret': auth_secret
+                        }
+                    })
+
                 # Append to combined kubeconfig
                 combined_kubeconfig['clusters'].extend(kubeconfig_yaml['clusters'])
                 combined_kubeconfig['contexts'].extend(kubeconfig_yaml['contexts'])

--- a/src/azure_utils.py
+++ b/src/azure_utils.py
@@ -158,7 +158,8 @@ def generate_kubeconfig_for_aks(clusters, workspace_info):
                             'cluster_type': 'aks',
                             'cluster_name': cluster_name,
                             'auth_type': auth_type,
-                            'auth_secret': auth_secret
+                            'auth_secret': auth_secret,
+                            'subscription_id': sub_id
                         }
                     })
 

--- a/src/enrichers/azure.py
+++ b/src/enrichers/azure.py
@@ -51,6 +51,15 @@ class AzurePlatformHandler(PlatformHandler):
         tags = resource_data.get('tags', dict())
         resource_attributes = {'tags': tags}
 
+        # Check if subscription_id is part of resource_data and add it to attributes if available
+        subscription_id = resource_data.get('subscription_id')
+        if subscription_id:
+            resource_attributes['subscription_id'] = subscription_id
+            logger.info(f"Resource '{name}' includes subscription_id: {subscription_id}")
+        else:
+            logger.warning(f"Resource '{name}' does not contain subscription_id in data.")
+
+
         if resource_type_name == "resource_group":
             # Set the 'lod' (level-of-detail) resource attribute from the per-resource-group
             # setting in the Azure cloud config or set to the default value if it's unspecified

--- a/src/map-customization-rules/az-rg-rules.yaml
+++ b/src/map-customization-rules/az-rg-rules.yaml
@@ -30,3 +30,10 @@ spec:
         matchMode: substring
         properties: [name]
       group: "{{resource_group.name}}"
+    - match:
+        type: pattern
+        matchType: base-name
+        pattern: "az-aks-triage"
+        matchMode: substring
+        properties: [name]
+      group: "{{resource_group.name}}"


### PR DESCRIPTION
Revers an unintended issue where the auth type metadata was stripped from the kubeconfig extensions