### PR TITLE
switch devcontainer and taskfile to use daemonless buildkit

### DIFF
--- a/.devcontainer.json
+++ b/.devcontainer.json
@@ -6,11 +6,7 @@
     "features": {
         "ghcr.io/devcontainers/features/docker-in-docker:2": {}
     },
-    "mounts": [
-        "source=/var/run/docker.sock,target=/var/run/docker.sock,type=bind", 
-        "source=/home/runwhen/runwhen-local/.test/azure/single-aks-acr,target=/workspace/.test/azure/single-aks-acr,type=bind",
-    ],
-    "postCreateCommand": "sudo chgrp docker /var/run/docker.sock && sudo chmod 660 /var/run/docker.sock",
+    "postCreateCommand": "docker buildx create --name mybuilder --driver docker-container --use && docker buildx inspect mybuilder --bootstrap &&  git config --unset http.https://github.com/.extraheader",
     "workspaceFolder": "/home/runwhen/runwhen-local",
     "remoteUser": "runwhen",
     "customizations": {
@@ -28,20 +24,16 @@
                 "python.linting.pylintEnabled": true,
                 "python.linting.pylintArgs": [
                     "--max-line-length=120",
-                    "--enable=W0614" // track unused imports
+                    "--enable=W0614"
                 ],
                 "[python]": {
                     "editor.insertSpaces": true,
                     "editor.tabSize": 4
                 },
                 "editor.formatOnSave": true,
-                "editor.lineNumbers": "on",
-                "python.formatting.provider": "black",
-                "python.formatting.blackArgs": [
-                    "--line-length",
-                    "120"
-                ]
+                "editor.lineNumbers": "on"
             }
         }
     }
 }
+ 

--- a/.test/azure/multi-subscription-aks/Taskfile.yaml
+++ b/.test/azure/multi-subscription-aks/Taskfile.yaml
@@ -33,32 +33,32 @@ tasks:
         branch_name=$(git rev-parse --abbrev-ref HEAD)
         codebundle=$(basename "$(dirname "$PWD")")
 
-        # Fetch individual cluster details from Terraform state
-        pushd terraform > /dev/null
-        cluster1_name=$(terraform show -json terraform.tfstate | jq -r '
-          .values.outputs.cluster_1_name.value')
-        cluster1_server=$(terraform show -json terraform.tfstate | jq -r '
-          .values.outputs.cluster_1_fqdn.value')
-        cluster1_resource_group=$(terraform show -json terraform.tfstate | jq -r '
-          .values.outputs.cluster_1_rg.value')
-        cluster1_sub=$(terraform show -json terraform.tfstate | jq -r '
-          .values.outputs.cluster_1_sub.value')
+        # # Fetch individual cluster details from Terraform state
+        # pushd terraform > /dev/null
+        # cluster1_name=$(terraform show -json terraform.tfstate | jq -r '
+        #   .values.outputs.cluster_1_name.value')
+        # cluster1_server=$(terraform show -json terraform.tfstate | jq -r '
+        #   .values.outputs.cluster_1_fqdn.value')
+        # cluster1_resource_group=$(terraform show -json terraform.tfstate | jq -r '
+        #   .values.outputs.cluster_1_rg.value')
+        # cluster1_sub=$(terraform show -json terraform.tfstate | jq -r '
+        #   .values.outputs.cluster_1_sub.value')
 
-        cluster2_name=$(terraform show -json terraform.tfstate | jq -r '
-          .values.outputs.cluster_2_name.value')
-        cluster2_server=$(terraform show -json terraform.tfstate | jq -r '
-          .values.outputs.cluster_2_fqdn.value')
-        cluster2_resource_group=$(terraform show -json terraform.tfstate | jq -r '
-          .values.outputs.cluster_2_rg.value')
-        cluster2_sub=$(terraform show -json terraform.tfstate | jq -r '
-          .values.outputs.cluster_2_sub.value')
-        popd > /dev/null
+        # cluster2_name=$(terraform show -json terraform.tfstate | jq -r '
+        #   .values.outputs.cluster_2_name.value')
+        # cluster2_server=$(terraform show -json terraform.tfstate | jq -r '
+        #   .values.outputs.cluster_2_fqdn.value')
+        # cluster2_resource_group=$(terraform show -json terraform.tfstate | jq -r '
+        #   .values.outputs.cluster_2_rg.value')
+        # cluster2_sub=$(terraform show -json terraform.tfstate | jq -r '
+        #   .values.outputs.cluster_2_sub.value')
+        # popd > /dev/null
 
-        # Check if any of the required cluster variables are empty
-        if [ -z "$cluster1_name" ] || [ -z "$cluster1_server" ] || [ -z "$cluster1_resource_group" ]; then
-          echo "Error: Missing cluster details. Ensure Terraform plan has been applied."
-          exit 1
-        fi
+        # # Check if any of the required cluster variables are empty
+        # if [ -z "$cluster1_name" ] || [ -z "$cluster1_server" ] || [ -z "$cluster1_resource_group" ]; then
+        #   echo "Error: Missing cluster details. Ensure Terraform plan has been applied."
+        #   exit 1
+        # fi
 
         # Generate workspaceInfo.yaml with fetched cluster details
         cat <<EOF > workspaceInfo.yaml
@@ -86,8 +86,8 @@ tasks:
               $cluster1_resource_group: detailed
               $cluster2_resource_group: detailed
         codeCollections: 
-          - repoURL: "https://github.com/stewartshea/rw-cli-codecollection"
-            branch: "azure/add_sub_vars"
+          - repoURL: "https://github.com/runwhen-contrib/rw-cli-codecollection"
+            branch: "main"
             codeBundles: ["k8s-namespace-healthcheck", "azure-aks-triage", "k8s-deployment-healthcheck"]
         # codeCollections: []
         # - repoURL: "$repo_url"
@@ -102,7 +102,7 @@ tasks:
     desc: "Run RunWhen Local Discovery on test infrastructure"
     cmds:
       - |
-        BUILD_DIR=/workspace/runwhen-local/src
+        BUILD_DIR=/home/runwhen/runwhen-local/src
         CONTAINER_NAME="RunWhenLocal"
         if docker ps -q --filter "name=$CONTAINER_NAME" | grep -q .; then
           echo "Stopping and removing existing container $CONTAINER_NAME..."
@@ -119,11 +119,11 @@ tasks:
         mkdir output && chmod 777 output || { echo "Failed to set permissions"; exit 1; }
 
         ## Building Container Image
-        docker build -t runwhen-local:test -f $BUILD_DIR/Dockerfile $BUILD_DIR
+        docker buildx build --builder mybuilder --platform linux/amd64  -t runwhen-local:test -f $BUILD_DIR/Dockerfile $BUILD_DIR --load
 
         echo "Starting new container $CONTAINER_NAME..."
 
-        docker run --name $CONTAINER_NAME -p 8081:8081 -v "$(pwd)":/shared -d runwhen-local:test || {
+        docker run --name $CONTAINER_NAME -p 8081:8081 -v $(pwd):/shared -d runwhen-local:test || {
           echo "Failed to start container"; exit 1;
         }
 


### PR DESCRIPTION
This should resolve some left over issues from migrating the cloud dev env from gitpod to codespaces/devcontainer. It leverages buildx/buildkit instead of the shared daemon as to preseve sharing of the working directory into the tested image with docker-in-docker. 