### PR TITLE
update map customization rules. add debug. add basic test taskfiles

### DIFF
--- a/.test/aws/basic/README.md
+++ b/.test/aws/basic/README.md
@@ -1,0 +1,38 @@
+# basic
+This test infrastructure performs basic discovery with a user provided workspaceInfo.yaml. 
+- `task run-rwl-discovery` - build and run the container image from source, indexing the aks cluster and any clusters in the kubeconfig.
+
+### workspaceInfo.yaml
+Provide a specific workspaceInfo.yaml
+```
+workspaceName: "my-workspace"
+workspaceOwnerEmail: authors@runwhen.com
+defaultLocation: location-01-us-west1
+defaultLOD: detailed
+cloudConfig:
+  aws: 
+    awsAccessKeyId: ""
+    awsSecretAccessKey: ""
+codeCollections:
+- repoURL: "https://github.com/runwhen-contrib/aws-c7n-codecollection"
+  branch: "rds_test"
+  codeBundles: ["aws-c7n-rds-health"]
+custom:
+  aws_access_key_id: AWS_ACCESS_KEY_ID
+  aws_secret_access_key: AWS_SECRET_ACCESS_KEY
+
+```
+
+
+## Running Test
+By default, running `task` will run the following tasks: 
+- run-rwl-discovery (which builds and then runs the container)
+```
+task 
+```
+
+
+## Cleanup
+```
+task clean
+```

--- a/.test/aws/basic/Taskfile.yaml
+++ b/.test/aws/basic/Taskfile.yaml
@@ -1,0 +1,58 @@
+version: "3"
+
+tasks:
+  default:
+    desc: "Generate workspaceInfo and rebuild/test"
+    cmds:
+      - task: run-rwl-discovery
+
+  clean:
+    desc: "Run cleanup tasks"
+    cmds:
+      - task: clean-rwl-discovery
+
+
+  run-rwl-discovery:
+    desc: "Run RunWhen Local Discovery on test infrastructure"
+    cmds:
+      - |
+        BUILD_DIR=/home/runwhen/runwhen-local/src
+        CONTAINER_NAME="RunWhenLocal"
+        if docker ps -q --filter "name=$CONTAINER_NAME" | grep -q .; then
+          echo "Stopping and removing existing container $CONTAINER_NAME..."
+          docker stop $CONTAINER_NAME && docker rm $CONTAINER_NAME
+        elif docker ps -a -q --filter "name=$CONTAINER_NAME" | grep -q .; then
+          echo "Removing existing stopped container $CONTAINER_NAME..."
+          docker rm $CONTAINER_NAME
+        else
+          echo "No existing container named $CONTAINER_NAME found."
+        fi
+        
+        echo "Cleaning up output directory..."
+        rm -rf output || { echo "Failed to remove output directory"; exit 1; }
+        mkdir output && chmod 777 output || { echo "Failed to set permissions"; exit 1; }
+
+        ## Building Container Image
+        docker buildx build --builder mybuilder --platform linux/amd64  -t runwhen-local:test -f $BUILD_DIR/Dockerfile $BUILD_DIR --load
+
+        echo "Starting new container $CONTAINER_NAME..."
+
+        docker run -e DEBUG_LOGGING=true --name $CONTAINER_NAME -p 8081:8081 -v $(pwd):/shared -d runwhen-local:test || {
+          echo "Failed to start container"; exit 1;
+        }
+
+        echo "Running workspace builder script in container..."
+        docker exec -w /workspace-builder $CONTAINER_NAME ./run.sh $1 --verbose || {
+          echo "Error executing script in container"; exit 1;
+        }
+
+        echo "Review generated config files under output/workspaces/"
+    silent: true
+
+  clean-rwl-discovery:
+    desc: "Check and clean up RunWhen Local discovery output"
+    cmds:
+      - |
+        rm -rf output
+        rm workspaceInfo.yaml
+    silent: true

--- a/.test/k8s/basic/README.md
+++ b/.test/k8s/basic/README.md
@@ -1,0 +1,29 @@
+# basic
+This test infrastructure performs basic k8s discovery with a user provided kubeconfig.secret/
+- `task generate-rwl-config` - build the basic rwl config
+- `task run-rwl-discovery` - build and run the container image from source, indexing the aks cluster and any clusters in the kubeconfig.
+
+### workspaceInfo.yaml
+Provide a specific workspaceInfo.yaml
+```
+
+
+```
+
+## Kubeconfig 
+A file called `kubeconfig.secret` should exist in this directory, it will be git ignored, but is configured in the workspaceInfo.yaml 
+to test the indexing of a vanilla kubernetes configuration. 
+
+## Running Test
+By default, running `task` will run the following tasks: 
+- generate-rwl-config
+- run-rwl-discovery (which builds and then runs the container)
+```
+task 
+```
+
+
+## Cleanup
+```
+task clean
+```

--- a/.test/k8s/basic/Taskfile.yaml
+++ b/.test/k8s/basic/Taskfile.yaml
@@ -1,0 +1,82 @@
+version: "3"
+
+tasks:
+  default:
+    desc: "Generate workspaceInfo and rebuild/test"
+    cmds:
+      - task: generate-rwl-config
+      - task: run-rwl-discovery
+
+  clean:
+    desc: "Run cleanup tasks"
+    cmds:
+      - task: clean-rwl-discovery
+
+  generate-rwl-config:
+    desc: "Generate RunWhen Local configuration (workspaceInfo.yaml)"
+    env:
+      RW_WORKSPACE: '{{.RW_WORKSPACE | default "my-workspace"}}'
+    cmds:
+      - |
+        # Generate workspaceInfo.yaml with fetched cluster details
+        cat <<EOF > workspaceInfo.yaml
+        workspaceName: "$RW_WORKSPACE"
+        workspaceOwnerEmail: authors@runwhen.com
+        defaultLocation: location-01
+        defaultLOD: detailed
+        cloudConfig:
+          kubernetes: 
+            kubeconfigFile: /shared/kubeconfig.secret
+        codeCollections: 
+          - repoURL: "https://github.com/runwhen-contrib/rw-cli-codecollection"
+            branch: "main"
+            codeBundles: ["k8s-namespace-healthcheck", "k8s-deployment-healthcheck"]
+        custom: 
+          kubernetes_distribution_binary: kubectl
+        EOF
+    silent: true
+
+  run-rwl-discovery:
+    desc: "Run RunWhen Local Discovery on test infrastructure"
+    cmds:
+      - |
+        BUILD_DIR=/home/runwhen/runwhen-local/src
+        CONTAINER_NAME="RunWhenLocal"
+        if docker ps -q --filter "name=$CONTAINER_NAME" | grep -q .; then
+          echo "Stopping and removing existing container $CONTAINER_NAME..."
+          docker stop $CONTAINER_NAME && docker rm $CONTAINER_NAME
+        elif docker ps -a -q --filter "name=$CONTAINER_NAME" | grep -q .; then
+          echo "Removing existing stopped container $CONTAINER_NAME..."
+          docker rm $CONTAINER_NAME
+        else
+          echo "No existing container named $CONTAINER_NAME found."
+        fi
+        
+        echo "Cleaning up output directory..."
+        rm -rf output || { echo "Failed to remove output directory"; exit 1; }
+        mkdir output && chmod 777 output || { echo "Failed to set permissions"; exit 1; }
+
+        ## Building Container Image
+        docker buildx build --builder mybuilder --platform linux/amd64  -t runwhen-local:test -f $BUILD_DIR/Dockerfile $BUILD_DIR --load
+
+        echo "Starting new container $CONTAINER_NAME..."
+
+        docker run -e DEBUG_LOGGING=true --name $CONTAINER_NAME -p 8081:8081 -v $(pwd):/shared -d runwhen-local:test || {
+          echo "Failed to start container"; exit 1;
+        }
+
+        echo "Running workspace builder script in container..."
+        docker exec -w /workspace-builder $CONTAINER_NAME ./run.sh $1 --verbose || {
+          echo "Error executing script in container"; exit 1;
+        }
+
+        echo "Review generated config files under output/workspaces/"
+    silent: true
+
+  clean-rwl-discovery:
+    desc: "Check and clean up RunWhen Local discovery output"
+    cmds:
+      - |
+        rm -rf output
+        rm workspaceInfo.yaml
+    silent: true

--- a/src/VERSION
+++ b/src/VERSION
@@ -1,4 +1,4 @@
 {
   "name":    "runwhen-local",
-  "version": "0.8.5"
+  "version": "0.8.6"
 }

--- a/src/enrichers/map_customization_rules.py
+++ b/src/enrichers/map_customization_rules.py
@@ -149,10 +149,21 @@ class SLXPropertyMatchPredicate(MatchPredicate):
                 except AttributeError:
                     resource = slx_info.resource
                 match = match_path(resource, self.match_property, match_func)
+                logger.debug(
+                    f"SLXPropertyMatchPredicate: property='{self.match_property}', pattern='{self.match_pattern}', "
+                    f"resource='{resource}', match={match}"
+                )
                 return match
         if match_value is None:
+            logger.debug(
+                f"SLXPropertyMatchPredicate: property='{self.match_property}', no value found in SLXInfo qualifiers."
+            )
             return False
         match = matches_pattern(match_value, self.match_pattern, self.string_match_mode)
+        logger.debug(
+            f"SLXPropertyMatchPredicate: property='{self.match_property}', value='{match_value}', "
+            f"pattern='{self.match_pattern}', match={match}"
+        )
         return match
 
 

--- a/src/map-customization-rules/aws-account-region.yaml
+++ b/src/map-customization-rules/aws-account-region.yaml
@@ -5,6 +5,6 @@ spec:
     - match:
         type: pattern
         matchType: base-name
-        pattern: "gcp-function-health"
+        pattern: "aws-c7n-rds-health"
         matchMode: exact
-      group: "GCP Project {{project.name}} Resources"
+      group: "AWS Region {{region}} (Account {{account_id}})"

--- a/src/map-customization-rules/az-rg-rules.yaml
+++ b/src/map-customization-rules/az-rg-rules.yaml
@@ -6,34 +6,29 @@ spec:
         type: pattern
         matchType: base-name
         pattern: "az-lb-health"
-        matchMode: substring
-        properties: [name]
+        matchMode: exact
       group: "{{resource_group.name}}"
     - match:
         type: pattern
         matchType: base-name
         pattern: "az-appgw-health"
-        matchMode: substring
-        properties: [name]
+        matchMode: exact
       group: "{{resource_group.name}}"
     - match:
         type: pattern
         matchType: base-name
         pattern: "az-appsvc-triage"
-        matchMode: substring
-        properties: [name]
+        matchMode: exact
       group: "{{resource_group.name}}"
     - match:
         type: pattern
         matchType: base-name
         pattern: "az-vm-triage"
-        matchMode: substring
-        properties: [name]
+        matchMode: exact
       group: "{{resource_group.name}}"
     - match:
         type: pattern
         matchType: base-name
         pattern: "az-aks-triage"
-        matchMode: substring
-        properties: [name]
+        matchMode: exact
       group: "{{resource_group.name}}"

--- a/src/map-customization-rules/ingress.yaml
+++ b/src/map-customization-rules/ingress.yaml
@@ -6,20 +6,17 @@ spec:
         type: pattern
         matchType: base-name
         pattern: "http-ok"
-        matchMode: substring
-        properties: [name]
+        matchMode: exact
       group: "Public HTTP Endpoint Health"
     - match:
         type: pattern
         matchType: base-name
         pattern: "ingress-health"
-        matchMode: substring
-        properties: [name]
+        matchMode: exact
       group: "{{namespace.name}} ({{cluster.name}})"
     - match:
         type: pattern
         matchType: base-name
         pattern: "ingress-gce-health"
-        matchMode: substring
-        properties: [name]
+        matchMode: exact
       group: "{{namespace.name}} ({{cluster.name}})"

--- a/src/map-customization-rules/namespace-based-rules.yaml
+++ b/src/map-customization-rules/namespace-based-rules.yaml
@@ -6,36 +6,31 @@ spec:
         type: pattern
         matchType: base-name
         pattern: "ngx-ing-gmp"
-        matchMode: substring
-        properties: [name]
+        matchMode: exact
       group: "{{namespace.name}} ({{cluster.name}})"
     - match:
         type: pattern
         matchType: base-name
         pattern: "ns-health"
-        matchMode: substring
-        properties: [name]
+        matchMode: exact
       group: "{{namespace.name}} ({{cluster.name}})"
     - match:
         type: pattern
         matchType: base-name
         pattern: "redis-health"
-        matchMode: substring
-        properties: [name]
+        matchMode: exact
       group: "{{namespace.name}} ({{cluster.name}})"
     - match:
         type: pattern
         matchType: base-name
         pattern: "ss-health"
-        matchMode: substring
-        properties: [name]
+        matchMode: exact
       group: "{{namespace.name}} ({{cluster.name}})"
     - match:
         type: pattern
         matchType: base-name
         pattern: "ds-health"
-        matchMode: substring
-        properties: [name]
+        matchMode: exact
       group: "{{namespace.name}} ({{cluster.name}})"
     - match:
         type: pattern
@@ -47,22 +42,19 @@ spec:
         type: pattern
         matchType: base-name
         pattern: "kong-ing-health"
-        matchMode: substring
-        properties: [name]
+        matchMode: exact
       group: "{{namespace.name}} ({{cluster.name}})"
     - match:
         type: pattern
         matchType: base-name
         pattern: "pvc-health"
-        matchMode: substring
-        properties: [name]
+        matchMode: exact
       group: "{{namespace.name}} ({{cluster.name}})"
     - match:
         type: pattern
         matchType: base-name
         pattern: "pod-resources"
-        matchMode: substring
-        properties: [name]
+        matchMode: exact
       group: "{{namespace.name}} ({{cluster.name}})"
     - match:
         type: pattern


### PR DESCRIPTION
This addresses an issue where the map customization rules were too inclusive, causing the string of another generation rule to cause a match, but failing to render since the appropriate variables didn't exist (specifically, trying to put an aws template into a match with kubernetes group names). 

This also adds some debug lines for troubleshooting group customization issues, along with some basic test taskfiles. 