### PR TITLE
add in per-cluster namespace LOD configurations

### DIFF
--- a/.test/azure/aks-and-k8s/Taskfile.yaml
+++ b/.test/azure/aks-and-k8s/Taskfile.yaml
@@ -57,10 +57,10 @@ tasks:
         workspaceName: "$RW_WORKSPACE"
         workspaceOwnerEmail: authors@runwhen.com
         defaultLocation: location-01
-        defaultLOD: detailed
+        defaultLOD: none
         cloudConfig:
-          kubernetes: 
-            kubeconfigFile: /shared/kubeconfig.secret
+          kubernetes: null            
+          # kubeconfigFile: /shared/kubeconfig.secret
           azure:
             subscriptionId: "$ARM_SUBSCRIPTION_ID"
             tenantId: "$AZ_TENANT_ID"
@@ -72,12 +72,14 @@ tasks:
                   server: https://$cluster_server:443
                   resource_group: $cluster_resource_group
                   subscriptionId: $cluster_sub
+                  defaultNamespaceLOD: detailed
             resourceGroupLevelOfDetails:
               $cluster_resource_group: detailed
         codeCollections: 
           - repoURL: "https://github.com/runwhen-contrib/rw-cli-codecollection"
             branch: "main"
-            codeBundles: ["k8s-namespace-healthcheck", "azure-aks-triage", "k8s-deployment-healthcheck"]
+            # codeBundles: ["k8s-namespace-healthcheck", "azure-aks-triage", "k8s-deployment-healthcheck"]
+            codeBundles: ["*"]
         custom: 
           kubernetes_distribution_binary: kubectl
         EOF

--- a/.test/azure/aks-and-k8s/terraform/main.tf
+++ b/.test/azure/aks-and-k8s/terraform/main.tf
@@ -1,8 +1,21 @@
+# Current sub (assumed from CLI login)
+data "azurerm_subscription" "current" {}
+
+# Get tenant and user details of the current CLI session
+data "azurerm_client_config" "current" {}
+
+
+# Assign the current logged-in user as a Kubernetes RBAC Cluster Admin
+resource "azurerm_role_assignment" "current_user_k8s_admin" {
+  principal_id         = data.azurerm_client_config.current.object_id
+  role_definition_name = "Azure Kubernetes Service RBAC Cluster Admin"
+  scope                = azurerm_kubernetes_cluster.cluster_aks.id
+}
+
 # Cluster 1 Resources
 
 # Resource Group
 resource "azurerm_resource_group" "cluster_rg" {
-  provider = azurerm.cluster
   name     = "azure-aks-k8s-1"
   location = "East US"
   tags = {
@@ -14,7 +27,6 @@ resource "azurerm_resource_group" "cluster_rg" {
 
 # Managed Identity
 resource "azurerm_user_assigned_identity" "cluster_identity" {
-  provider            = azurerm.cluster
   name                = "aks-cl-1-identity"
   location            = azurerm_resource_group.cluster_rg.location
   resource_group_name = azurerm_resource_group.cluster_rg.name
@@ -22,7 +34,6 @@ resource "azurerm_user_assigned_identity" "cluster_identity" {
 
 # Role Assignment for Service Principal
 resource "azurerm_role_assignment" "cluster_sp_owner" {
-  provider             = azurerm.cluster
   scope                = "/subscriptions/${var.subscription_id}"
   role_definition_name = "Azure Kubernetes Service RBAC Cluster Admin"
   principal_id         = var.sp_principal_id
@@ -30,7 +41,6 @@ resource "azurerm_role_assignment" "cluster_sp_owner" {
 }
 # Role Assignment for Service Principal
 resource "azurerm_role_assignment" "cluster_sp_reader" {
-  provider             = azurerm.cluster
   scope                = "/subscriptions/${var.subscription_id}"
   role_definition_name = "Reader"
   principal_id         = var.sp_principal_id
@@ -38,7 +48,6 @@ resource "azurerm_role_assignment" "cluster_sp_reader" {
 }
 # AKS Cluster
 resource "azurerm_kubernetes_cluster" "cluster_aks" {
-  provider            = azurerm.cluster
   name                = "aks-cl-1"
   location            = azurerm_resource_group.cluster_rg.location
   resource_group_name = azurerm_resource_group.cluster_rg.name

--- a/.test/azure/aks-and-k8s/terraform/provider.tf
+++ b/.test/azure/aks-and-k8s/terraform/provider.tf
@@ -9,7 +9,6 @@ terraform {
 
 provider "azurerm" {
   features {}
-  alias           = "cluster"
   subscription_id = var.subscription_id
   tenant_id       = var.tenant_id
 }

--- a/src/VERSION
+++ b/src/VERSION
@@ -1,4 +1,4 @@
 {
   "name": "runwhen-local",
-  "version": "0.8.9"
+  "version": "0.8.10"
 }


### PR DESCRIPTION
Resolve the namespace LOD settings needed in https://github.com/runwhen-contrib/runwhen-local/issues/680

This is so that a user can set the defaultLOD to none, specify desired resourceGroupLeveOfDetails that are separate from those in AKS clusters. 