### PR TITLE
Fix/lod-granulatiry

### DIFF
--- a/.test/azure/aks-and-k8s/Taskfile.yaml
+++ b/.test/azure/aks-and-k8s/Taskfile.yaml
@@ -305,7 +305,7 @@ tasks:
           cloudConfig:
             kubernetes:             
               kubeconfigFile: /shared/kubeconfig.secret
-              context:
+              contexts:
                 sandbox-cluster-1: 
                   defaultNamespaceLOD: none
             azure:
@@ -320,6 +320,135 @@ tasks:
                     resource_group: $cluster_resource_group
                     subscriptionId: $cluster_sub
                     defaultNamespaceLOD: none
+              resourceGroupLevelOfDetails:
+                $cluster_resource_group: detailed
+          codeCollections: []
+            # - repoURL: "https://github.com/runwhen-contrib/rw-cli-codecollection"
+            #   branch: "main"
+            #   codeBundles: ["k8s-namespace-healthcheck", "azure-aks-triage", "k8s-deployment-healthcheck"]
+          custom: 
+            kubernetes_distribution_binary: kubectl
+          EOF
+
+        - task: run-rwl-discovery
+      silent: true
+
+  ci-test-4:
+      desc: "Run CI Discovery Test 4 - AKS only - defaultLOD basic, no K8s Cluster, AKS defaultNamespaceLOD none, kube-system lod detailed from annotation"
+      env:
+        ARM_SUBSCRIPTION_ID: "{{.TF_VAR_subscription_id}}"
+        AZ_TENANT_ID: "{{.AZ_TENANT_ID}}"
+        AZ_CLIENT_SECRET: "{{.AZ_CLIENT_SECRET}}"
+        AZ_CLIENT_ID: "{{.AZ_CLIENT_ID}}"
+        RW_WORKSPACE: '{{.RW_WORKSPACE | default "my-workspace"}}'
+      cmds:
+        - |
+          repo_url=$(git config --get remote.origin.url)
+          branch_name=$(git rev-parse --abbrev-ref HEAD)
+          codebundle=$(basename "$(dirname "$PWD")")
+
+          # Fetch individual cluster details from Terraform state
+          pushd terraform > /dev/null
+          cluster_name=$(terraform show -json terraform.tfstate | jq -r '
+            .values.outputs.cluster_name.value')
+          cluster_server=$(terraform show -json terraform.tfstate | jq -r '
+            .values.outputs.cluster_fqdn.value')
+          cluster_resource_group=$(terraform show -json terraform.tfstate | jq -r '
+            .values.outputs.cluster_rg.value')
+          cluster_sub=$(terraform show -json terraform.tfstate | jq -r '
+            .values.outputs.cluster_sub.value')
+
+          popd > /dev/null
+
+          # Check if any of the required cluster variables are empty
+          if [ -z "$cluster_name" ] || [ -z "$cluster_server" ] || [ -z "$cluster_resource_group" ]; then
+            echo "Error: Missing cluster details. Ensure Terraform plan has been applied."
+            exit 1
+          fi
+
+          # Generate workspaceInfo.yaml with fetched cluster details
+          cat <<EOF > workspaceInfo.yaml
+          workspaceName: "$RW_WORKSPACE"
+          workspaceOwnerEmail: authors@runwhen.com
+          defaultLocation: location-01
+          defaultLOD: basic
+          cloudConfig:
+            kubernetes: null
+            azure:
+              subscriptionId: "$ARM_SUBSCRIPTION_ID"
+              tenantId: "$AZ_TENANT_ID"
+              clientId: "$AZ_CLIENT_ID"
+              clientSecret: "$AZ_CLIENT_SECRET"
+              aksClusters: 
+                clusters: 
+                  - name: $cluster_name
+                    server: https://$cluster_server:443
+                    resource_group: $cluster_resource_group
+                    subscriptionId: $cluster_sub
+                    defaultNamespaceLOD: none
+              resourceGroupLevelOfDetails:
+                $cluster_resource_group: detailed
+          codeCollections: []
+            # - repoURL: "https://github.com/runwhen-contrib/rw-cli-codecollection"
+            #   branch: "main"
+            #   codeBundles: ["k8s-namespace-healthcheck", "azure-aks-triage", "k8s-deployment-healthcheck"]
+          custom: 
+            kubernetes_distribution_binary: kubectl
+          EOF
+
+        - task: run-rwl-discovery
+      silent: true
+
+  ci-test-5:
+      desc: "Run CI Discovery Test 4 - K8s only - defaultLOD basic, K8s defaultNamespaceLOD basic, no AKS cluster"
+      env:
+        ARM_SUBSCRIPTION_ID: "{{.TF_VAR_subscription_id}}"
+        AZ_TENANT_ID: "{{.AZ_TENANT_ID}}"
+        AZ_CLIENT_SECRET: "{{.AZ_CLIENT_SECRET}}"
+        AZ_CLIENT_ID: "{{.AZ_CLIENT_ID}}"
+        RW_WORKSPACE: '{{.RW_WORKSPACE | default "my-workspace"}}'
+      cmds:
+        - |
+          repo_url=$(git config --get remote.origin.url)
+          branch_name=$(git rev-parse --abbrev-ref HEAD)
+          codebundle=$(basename "$(dirname "$PWD")")
+
+          # Fetch individual cluster details from Terraform state
+          pushd terraform > /dev/null
+          cluster_name=$(terraform show -json terraform.tfstate | jq -r '
+            .values.outputs.cluster_name.value')
+          cluster_server=$(terraform show -json terraform.tfstate | jq -r '
+            .values.outputs.cluster_fqdn.value')
+          cluster_resource_group=$(terraform show -json terraform.tfstate | jq -r '
+            .values.outputs.cluster_rg.value')
+          cluster_sub=$(terraform show -json terraform.tfstate | jq -r '
+            .values.outputs.cluster_sub.value')
+
+          popd > /dev/null
+
+          # Check if any of the required cluster variables are empty
+          if [ -z "$cluster_name" ] || [ -z "$cluster_server" ] || [ -z "$cluster_resource_group" ]; then
+            echo "Error: Missing cluster details. Ensure Terraform plan has been applied."
+            exit 1
+          fi
+
+          # Generate workspaceInfo.yaml with fetched cluster details
+          cat <<EOF > workspaceInfo.yaml
+          workspaceName: "$RW_WORKSPACE"
+          workspaceOwnerEmail: authors@runwhen.com
+          defaultLocation: location-01
+          defaultLOD: none
+          cloudConfig:
+            kubernetes:             
+              kubeconfigFile: /shared/kubeconfig.secret
+              contexts:
+                sandbox-cluster-1: 
+                  defaultNamespaceLOD: basic
+            azure:
+              subscriptionId: "$ARM_SUBSCRIPTION_ID"
+              tenantId: "$AZ_TENANT_ID"
+              clientId: "$AZ_CLIENT_ID"
+              clientSecret: "$AZ_CLIENT_SECRET"
               resourceGroupLevelOfDetails:
                 $cluster_resource_group: detailed
           codeCollections: []

--- a/.test/azure/aks-and-k8s/Taskfile.yaml
+++ b/.test/azure/aks-and-k8s/Taskfile.yaml
@@ -59,8 +59,11 @@ tasks:
         defaultLocation: location-01
         defaultLOD: none
         cloudConfig:
-          kubernetes: null            
-          # kubeconfigFile: /shared/kubeconfig.secret
+          kubernetes:             
+            kubeconfigFile: /shared/kubeconfig.secret
+            contexts: 
+              sandbox-cluster-1: 
+                defaultNamespaceLOD: basic
           azure:
             subscriptionId: "$ARM_SUBSCRIPTION_ID"
             tenantId: "$AZ_TENANT_ID"
@@ -75,11 +78,10 @@ tasks:
                   defaultNamespaceLOD: detailed
             resourceGroupLevelOfDetails:
               $cluster_resource_group: detailed
-        codeCollections: 
-          - repoURL: "https://github.com/runwhen-contrib/rw-cli-codecollection"
-            branch: "main"
-            # codeBundles: ["k8s-namespace-healthcheck", "azure-aks-triage", "k8s-deployment-healthcheck"]
-            codeBundles: ["*"]
+        codeCollections: []
+          # - repoURL: "https://github.com/runwhen-contrib/rw-cli-codecollection"
+          #   branch: "main"
+          #   codeBundles: ["k8s-namespace-healthcheck", "azure-aks-triage", "k8s-deployment-healthcheck"]
         custom: 
           kubernetes_distribution_binary: kubectl
         EOF
@@ -120,7 +122,241 @@ tasks:
         }
 
         echo "Review generated config files under output/workspaces/"
+        echo "Total SLXs: $(find $(find 'output/' -type d -name 'slxs') -mindepth 1 -type d | wc -l)"
     silent: true
+
+
+  ci-test-1:
+    desc: "Run CI Discovery Test 1 - K8s & AKS - defaultLOD None, K8s context defaultNamespaceLOD Basic, AKS defaultNamespaceLOD Detailed"
+    env:
+      ARM_SUBSCRIPTION_ID: "{{.TF_VAR_subscription_id}}"
+      AZ_TENANT_ID: "{{.AZ_TENANT_ID}}"
+      AZ_CLIENT_SECRET: "{{.AZ_CLIENT_SECRET}}"
+      AZ_CLIENT_ID: "{{.AZ_CLIENT_ID}}"
+      RW_WORKSPACE: '{{.RW_WORKSPACE | default "my-workspace"}}'
+    cmds:
+      - |
+        repo_url=$(git config --get remote.origin.url)
+        branch_name=$(git rev-parse --abbrev-ref HEAD)
+        codebundle=$(basename "$(dirname "$PWD")")
+
+        # Fetch individual cluster details from Terraform state
+        pushd terraform > /dev/null
+        cluster_name=$(terraform show -json terraform.tfstate | jq -r '
+          .values.outputs.cluster_name.value')
+        cluster_server=$(terraform show -json terraform.tfstate | jq -r '
+          .values.outputs.cluster_fqdn.value')
+        cluster_resource_group=$(terraform show -json terraform.tfstate | jq -r '
+          .values.outputs.cluster_rg.value')
+        cluster_sub=$(terraform show -json terraform.tfstate | jq -r '
+          .values.outputs.cluster_sub.value')
+
+        popd > /dev/null
+
+        # Check if any of the required cluster variables are empty
+        if [ -z "$cluster_name" ] || [ -z "$cluster_server" ] || [ -z "$cluster_resource_group" ]; then
+          echo "Error: Missing cluster details. Ensure Terraform plan has been applied."
+          exit 1
+        fi
+
+        # Generate workspaceInfo.yaml with fetched cluster details
+        cat <<EOF > workspaceInfo.yaml
+        workspaceName: "$RW_WORKSPACE"
+        workspaceOwnerEmail: authors@runwhen.com
+        defaultLocation: location-01
+        defaultLOD: none
+        cloudConfig:
+          kubernetes:             
+            kubeconfigFile: /shared/kubeconfig.secret
+            contexts: 
+              sandbox-cluster-1: 
+                defaultNamespaceLOD: basic
+          azure:
+            subscriptionId: "$ARM_SUBSCRIPTION_ID"
+            tenantId: "$AZ_TENANT_ID"
+            clientId: "$AZ_CLIENT_ID"
+            clientSecret: "$AZ_CLIENT_SECRET"
+            aksClusters: 
+              clusters: 
+                - name: $cluster_name
+                  server: https://$cluster_server:443
+                  resource_group: $cluster_resource_group
+                  subscriptionId: $cluster_sub
+                  defaultNamespaceLOD: detailed
+            resourceGroupLevelOfDetails:
+              $cluster_resource_group: detailed
+        codeCollections: []
+          # - repoURL: "https://github.com/runwhen-contrib/rw-cli-codecollection"
+          #   branch: "main"
+          #   codeBundles: ["k8s-namespace-healthcheck", "azure-aks-triage", "k8s-deployment-healthcheck"]
+        custom: 
+          kubernetes_distribution_binary: kubectl
+        EOF
+
+      - task: run-rwl-discovery
+    silent: true
+
+  ci-test-2:
+      desc: "Run CI Discovery Test 2 - K8s & AKS - defaultLOD None, No K8s Context defaultNamespaceLOD, AKS defaultNamespaceLOD detailed"
+      env:
+        ARM_SUBSCRIPTION_ID: "{{.TF_VAR_subscription_id}}"
+        AZ_TENANT_ID: "{{.AZ_TENANT_ID}}"
+        AZ_CLIENT_SECRET: "{{.AZ_CLIENT_SECRET}}"
+        AZ_CLIENT_ID: "{{.AZ_CLIENT_ID}}"
+        RW_WORKSPACE: '{{.RW_WORKSPACE | default "my-workspace"}}'
+      cmds:
+        - |
+          repo_url=$(git config --get remote.origin.url)
+          branch_name=$(git rev-parse --abbrev-ref HEAD)
+          codebundle=$(basename "$(dirname "$PWD")")
+
+          # Fetch individual cluster details from Terraform state
+          pushd terraform > /dev/null
+          cluster_name=$(terraform show -json terraform.tfstate | jq -r '
+            .values.outputs.cluster_name.value')
+          cluster_server=$(terraform show -json terraform.tfstate | jq -r '
+            .values.outputs.cluster_fqdn.value')
+          cluster_resource_group=$(terraform show -json terraform.tfstate | jq -r '
+            .values.outputs.cluster_rg.value')
+          cluster_sub=$(terraform show -json terraform.tfstate | jq -r '
+            .values.outputs.cluster_sub.value')
+
+          popd > /dev/null
+
+          # Check if any of the required cluster variables are empty
+          if [ -z "$cluster_name" ] || [ -z "$cluster_server" ] || [ -z "$cluster_resource_group" ]; then
+            echo "Error: Missing cluster details. Ensure Terraform plan has been applied."
+            exit 1
+          fi
+
+          # Generate workspaceInfo.yaml with fetched cluster details
+          cat <<EOF > workspaceInfo.yaml
+          workspaceName: "$RW_WORKSPACE"
+          workspaceOwnerEmail: authors@runwhen.com
+          defaultLocation: location-01
+          defaultLOD: none
+          cloudConfig:
+            kubernetes:             
+              kubeconfigFile: /shared/kubeconfig.secret
+            azure:
+              subscriptionId: "$ARM_SUBSCRIPTION_ID"
+              tenantId: "$AZ_TENANT_ID"
+              clientId: "$AZ_CLIENT_ID"
+              clientSecret: "$AZ_CLIENT_SECRET"
+              aksClusters: 
+                clusters: 
+                  - name: $cluster_name
+                    server: https://$cluster_server:443
+                    resource_group: $cluster_resource_group
+                    subscriptionId: $cluster_sub
+                    defaultNamespaceLOD: detailed
+              resourceGroupLevelOfDetails:
+                $cluster_resource_group: detailed
+          codeCollections: []
+            # - repoURL: "https://github.com/runwhen-contrib/rw-cli-codecollection"
+            #   branch: "main"
+            #   codeBundles: ["k8s-namespace-healthcheck", "azure-aks-triage", "k8s-deployment-healthcheck"]
+          custom: 
+            kubernetes_distribution_binary: kubectl
+          EOF
+
+        - task: run-rwl-discovery
+      silent: true
+
+  ci-test-3:
+      desc: "Run CI Discovery Test 3 - K8s & AKS - defaultLOD detailed, K8s cluster defaultNamespaceLOD none, AKS defaultNamespaceLOD none"
+      env:
+        ARM_SUBSCRIPTION_ID: "{{.TF_VAR_subscription_id}}"
+        AZ_TENANT_ID: "{{.AZ_TENANT_ID}}"
+        AZ_CLIENT_SECRET: "{{.AZ_CLIENT_SECRET}}"
+        AZ_CLIENT_ID: "{{.AZ_CLIENT_ID}}"
+        RW_WORKSPACE: '{{.RW_WORKSPACE | default "my-workspace"}}'
+      cmds:
+        - |
+          repo_url=$(git config --get remote.origin.url)
+          branch_name=$(git rev-parse --abbrev-ref HEAD)
+          codebundle=$(basename "$(dirname "$PWD")")
+
+          # Fetch individual cluster details from Terraform state
+          pushd terraform > /dev/null
+          cluster_name=$(terraform show -json terraform.tfstate | jq -r '
+            .values.outputs.cluster_name.value')
+          cluster_server=$(terraform show -json terraform.tfstate | jq -r '
+            .values.outputs.cluster_fqdn.value')
+          cluster_resource_group=$(terraform show -json terraform.tfstate | jq -r '
+            .values.outputs.cluster_rg.value')
+          cluster_sub=$(terraform show -json terraform.tfstate | jq -r '
+            .values.outputs.cluster_sub.value')
+
+          popd > /dev/null
+
+          # Check if any of the required cluster variables are empty
+          if [ -z "$cluster_name" ] || [ -z "$cluster_server" ] || [ -z "$cluster_resource_group" ]; then
+            echo "Error: Missing cluster details. Ensure Terraform plan has been applied."
+            exit 1
+          fi
+
+          # Generate workspaceInfo.yaml with fetched cluster details
+          cat <<EOF > workspaceInfo.yaml
+          workspaceName: "$RW_WORKSPACE"
+          workspaceOwnerEmail: authors@runwhen.com
+          defaultLocation: location-01
+          defaultLOD: detailed
+          cloudConfig:
+            kubernetes:             
+              kubeconfigFile: /shared/kubeconfig.secret
+              context:
+                sandbox-cluster-1: 
+                  defaultNamespaceLOD: none
+            azure:
+              subscriptionId: "$ARM_SUBSCRIPTION_ID"
+              tenantId: "$AZ_TENANT_ID"
+              clientId: "$AZ_CLIENT_ID"
+              clientSecret: "$AZ_CLIENT_SECRET"
+              aksClusters: 
+                clusters: 
+                  - name: $cluster_name
+                    server: https://$cluster_server:443
+                    resource_group: $cluster_resource_group
+                    subscriptionId: $cluster_sub
+                    defaultNamespaceLOD: none
+              resourceGroupLevelOfDetails:
+                $cluster_resource_group: detailed
+          codeCollections: []
+            # - repoURL: "https://github.com/runwhen-contrib/rw-cli-codecollection"
+            #   branch: "main"
+            #   codeBundles: ["k8s-namespace-healthcheck", "azure-aks-triage", "k8s-deployment-healthcheck"]
+          custom: 
+            kubernetes_distribution_binary: kubectl
+          EOF
+
+        - task: run-rwl-discovery
+      silent: true
+
+  install-deployment: 
+    desc: "Install basic runwhen-local deployment"
+    cmds: 
+      - | 
+
+        # Fetch individual cluster details from Terraform state
+        pushd terraform > /dev/null
+        cluster_name=$(terraform show -json terraform.tfstate | jq -r '
+          .values.outputs.cluster_name.value')
+        cluster_server=$(terraform show -json terraform.tfstate | jq -r '
+          .values.outputs.cluster_fqdn.value')
+        cluster_resource_group=$(terraform show -json terraform.tfstate | jq -r '
+          .values.outputs.cluster_rg.value')
+        cluster_sub=$(terraform show -json terraform.tfstate | jq -r '
+          .values.outputs.cluster_sub.value')
+
+        popd > /dev/null
+        az aks get-credentials --resource-group $cluster_resource_group --name $cluster_name --overwrite-existing
+        kubelogin convert-kubeconfig -l azurecli
+        namespace=runwhen-local
+        kubectl create ns $namespace
+        helm repo add runwhen-contrib https://runwhen-contrib.github.io/helm-charts
+        helm repo update
+        helm install runwhen-local runwhen-contrib/runwhen-local -n $namespace
 
   check-terraform-infra:
     desc: "Check if Terraform has any deployed infrastructure in the terraform subdirectory"
@@ -178,6 +414,7 @@ tasks:
           exit 1
         }
         echo "Terraform infrastructure build completed."
+
     silent: true
 
   cleanup-terraform-infra:

--- a/src/VERSION
+++ b/src/VERSION
@@ -1,4 +1,4 @@
 {
   "name": "runwhen-local",
-  "version": "0.8.10"
+  "version": "0.9.0"
 }

--- a/src/enrichers/generation_rule_types.py
+++ b/src/enrichers/generation_rule_types.py
@@ -21,27 +21,37 @@ class LevelOfDetail(Enum):
     greater than or equal to the LOD value for the gen rule, then the
     gen rule is enabled.
     """
-    NONE = 0
-    BASIC = 1
-    DETAILED = 2
+    NONE = (0, "none")
+    BASIC = (1, "basic")
+    DETAILED = (2, "detailed")
+
+    def __init__(self, int_value, str_value):
+        self.int_value = int_value
+        self.str_value = str_value
 
     @staticmethod
     def construct_from_config(config: Any) -> "LevelOfDetail":
-        try:
-            if isinstance(config, int):
-                return LevelOfDetail(config)
-            elif isinstance(config, str):
-                return LevelOfDetail[config.upper()]
-        except (ValueError, KeyError):
-            pass
-        # FIXME: I think this should probably be a WorkspaceBuilderUserException, since
-        # this would most likely be the result of someone using an incorrect value in
-        # their workspace info data and thus would be user error. I guess it could also
-        # come from a value in a gen rule for a code bundle, but presumably that should
-        # get caught by the code bundle author and not be something that normal end
-        # users would see. But, anyway, I need to think about it some more and would
-        # need more testing for regressions, although I think it would just work.
+        if isinstance(config, LevelOfDetail):
+            return config  # Already a valid enum instance
+
+        if isinstance(config, int):  # If given an integer (0, 1, 2)
+            for lod in LevelOfDetail:
+                if lod.int_value == config:
+                    return lod
+
+        if isinstance(config, str):  # If given a string ("none", "basic", "detailed")
+            normalized_value = config.strip().lower()
+            for lod in LevelOfDetail:
+                if lod.str_value == normalized_value:
+                    return lod
+
         raise WorkspaceBuilderException(f"Invalid level of detail value: {config}")
+
+    def __str__(self) -> str:
+        return self.str_value  # Ensure string representation is always the expected string
+
+    def to_int(self) -> int:
+        return self.int_value  # Convert back to integer if needed
 
 # FIXME: It feels a bit kludgy to me to do the LevelOfDetail YAML serialization/deserialization
 # this way by setting shared class properties of the yaml module. I made an attempt


### PR DESCRIPTION
removes the specific namespaceLOD settings in place of existing or new settings (such as context or cluster specific defaultNamespaceLOD). 

Adds some test scenarios that are going to be evolved into automated ci tests once we lock down the sample set for consistency and load in some secrets. 

Tied to https://github.com/runwhen-contrib/runwhen-local/issues/680