### PR TITLE
Renamed the location settings to remove the "default" prefix

### DIFF
--- a/src/VERSION
+++ b/src/VERSION
@@ -1,4 +1,4 @@
 {
   "name": "runwhen-local",
-  "version": "0.9.0"
+  "version": "0.9.1"
 }

--- a/src/component.py
+++ b/src/component.py
@@ -371,15 +371,15 @@ WORKSPACE_OWNER_EMAIL_SETTING = Setting("WORKSPACE_OWNER_EMAIL",
 # Is there a reasonable default value to use for this?
 # i.e. Does this need to be a required setting from the user?
 # FIXME: Need a better doc string
-DEFAULT_LOCATION_SETTING = Setting("DEFAULT_LOCATION",
-                                   "defaultLocation",
-                                   Setting.Type.STRING,
-                                   "Default location")
+LOCATION_ID_SETTING = Setting("LOCATION_ID",
+                              "locationId",
+                              Setting.Type.STRING,
+                              "Location ID")
 
-DEFAULT_LOCATION_NAME_SETTING = Setting("DEFAULT_LOCATION_NAME",
-                                        "defaultLocationName",
-                                        Setting.Type.STRING,
-                                        "Default location name")
+LOCATION_NAME_SETTING = Setting("LOCATION_NAME",
+                                "locationName",
+                                Setting.Type.STRING,
+                                "Location name")
 
 WORKSPACE_OUTPUT_PATH_SETTING = Setting("WORKSPACE_OUTPUT_PATH",
                                         "workspaceOutputPath",

--- a/src/enrichers/generation_rules.py
+++ b/src/enrichers/generation_rules.py
@@ -12,8 +12,8 @@ from component import (
     WORKSPACE_NAME_SETTING,
     WORKSPACE_OWNER_EMAIL_SETTING,
     WORKSPACE_OUTPUT_PATH_SETTING,
-    DEFAULT_LOCATION_SETTING,
-    DEFAULT_LOCATION_NAME_SETTING,
+    LOCATION_ID_SETTING,
+    LOCATION_NAME_SETTING,
 )
 from exceptions import WorkspaceBuilderException
 from indexers.kubetypes import KUBERNETES_PLATFORM
@@ -106,8 +106,8 @@ SETTINGS = (
     SettingDependency(WORKSPACE_NAME_SETTING, True),
     SettingDependency(WORKSPACE_OWNER_EMAIL_SETTING, True),
     SettingDependency(WORKSPACE_OUTPUT_PATH_SETTING, True),
-    SettingDependency(DEFAULT_LOCATION_SETTING, True),
-    SettingDependency(DEFAULT_LOCATION_NAME_SETTING, False),
+    SettingDependency(LOCATION_ID_SETTING, True),
+    SettingDependency(LOCATION_NAME_SETTING, False),
     SettingDependency(DEFAULT_LOD_SETTING, False),
     SettingDependency(MAP_CUSTOMIZATION_RULES_SETTING, False),
     SettingDependency(CUSTOM_DEFINITIONS_SETTING, False),
@@ -988,12 +988,12 @@ def enrich(context: Context) -> None:
         workspace_output_path = "."
     workspace_path = os.path.join(workspace_output_path, workspace_name)
     slxs_path = os.path.join(workspace_path, "slxs")
-    default_location = context.get_setting("DEFAULT_LOCATION")
-    default_location_name = context.get_setting("DEFAULT_LOCATION_NAME")
-    if default_location_name:
-        location_qualifier = default_location_name
-    elif default_location:
-        location_qualifier = default_location
+    location_id = context.get_setting("LOCATION_ID")
+    location_name = context.get_setting("LOCATION_NAME")
+    if not location_name:
+        location_name = location_id
+    if location_name:
+        location_qualifier = location_name
     else:
         # I think either the default location id or name (or typically both) will always be
         # specified, but just to be safe...
@@ -1004,8 +1004,8 @@ def enrich(context: Context) -> None:
         'workspace_path': workspace_path,
         'wb_version': wb_version,
         'slxs_path': slxs_path,
-        'default_location': default_location,
-        'default_location_name': default_location_name,
+        'location_id': location_id,
+        'location_name': location_name,
         'generated_by': generated_by,
         'custom': custom_definitions,
         'shorten_name': shorten_name,
@@ -1072,7 +1072,9 @@ def enrich(context: Context) -> None:
     # Generate the workspace file
     workspace_template_variables = {
         'workspace': workspace,
-        'default_location': default_location,
+        'location_id': location_id,
+        'location_name': location_name,
+        'generated_by': generated_by,
         'custom': custom_definitions,
         'groups': groups,
         'slx_relationships': slx_relationships,

--- a/src/renderers/render_output_items.py
+++ b/src/renderers/render_output_items.py
@@ -4,7 +4,7 @@ import logging
 from typing import Any, Callable, Optional
 
 from component import Context, SettingDependency, WORKSPACE_NAME_SETTING, \
-    DEFAULT_LOCATION_SETTING, WORKSPACE_OUTPUT_PATH_SETTING
+    LOCATION_ID_SETTING, WORKSPACE_OUTPUT_PATH_SETTING
 from template import render_template_file
 
 logger = logging.getLogger(__name__)
@@ -17,8 +17,9 @@ else:
 
 DOCUMENTATION = "Render templated output items"
 
+# FIXME: Not sure these settings dependencies are still needed/valid?
 SETTINGS = (
-    SettingDependency(DEFAULT_LOCATION_SETTING, True),
+    SettingDependency(LOCATION_ID_SETTING, True),
     SettingDependency(WORKSPACE_NAME_SETTING, True),
     SettingDependency(WORKSPACE_OUTPUT_PATH_SETTING, True),
 )

--- a/src/run.py
+++ b/src/run.py
@@ -240,10 +240,10 @@ def main():
                         help="Name of the workspace to populate")
     parser.add_argument('--workspace-owner-email', action='store', dest="workspace_owner_email",
                         help="Email address to use as the owner of the workspace")
-    parser.add_argument('--default-location', action='store', dest="default_location",
-                        help="Default location to use for the generated workspace")
-    parser.add_argument('--default-location-name', action='store', dest="default_location_name",
-                        help="Default location name to use for the generated workspace")
+    parser.add_argument('--location-id', action='store', dest="location_id",
+                        help="Location ID to use for the generated workspace")
+    parser.add_argument('--location-name', action='store', dest="location_name",
+                        help="Location name to use for the generated workspace")
     parser.add_argument('--default-lod', action='store', dest='default_lod', type=str,
                         help='Default level of detail to use; valid values are "none", "basic", and "detailed".')
     parser.add_argument('--resource-dump-path', action='store', dest='resource_dump_path', type=str,
@@ -305,8 +305,8 @@ def main():
     # These have the highest precedence, i.e. over the same setting from the workspace info.
     workspace_name = args.workspace_name
     workspace_owner_email = args.workspace_owner_email
-    default_location = args.default_location
-    default_location_name = args.default_location_name
+    location_id = args.location_id
+    location_name = args.location_name
     papi_url = args.papi_url
     default_lod = args.default_lod
     namespaces = [ns.strip() for ns in args.namespaces.split(',')] if args.namespaces else None
@@ -345,10 +345,16 @@ def main():
             workspace_name = upload_info.get('workspaceName')
         if not workspace_owner_email:
             workspace_owner_email = upload_info.get('workspaceOwnerEmail')
-        if not default_location:
-            default_location = upload_info.get("defaultLocation")
-        if not default_location_name:
-            default_location_name = upload_info.get("defaultLocationName")
+        if not location_id:
+            location_id = upload_info.get("locationId")
+            # This is backwards compatibility code to support the old name that can eventually go away
+            if not location_id:
+                location_id = upload_info.get("defaultLocation")
+        if not location_name:
+            location_name = upload_info.get("locationName")
+            # This is backwards compatibility code to support the old name that can eventually go away
+            if not location_name:
+                location_name = upload_info.get("defaultLocationName")
     except FileNotFoundError:
         # Don't treat this as a fatal error, to handle untethered, pure
         # RunWhen Local operation. In this case we assume that the workspace name
@@ -380,8 +386,15 @@ def main():
                 papi_url = workspace_info.get('papiURL')
             if not workspace_owner_email:
                 workspace_owner_email = workspace_info.get('workspaceOwnerEmail')
-            if not default_location:
-                default_location = workspace_info.get("defaultLocation")
+            if not location_id:
+                location_id = workspace_info.get("locationId")
+                if not location_id:
+                    location_id = workspace_info.get("defaultLocation")
+            if not location_name:
+                location_name = workspace_info.get("locationName")
+                # This is backwards compatibility code to support the old name that can eventually go away
+                if not location_name:
+                    location_name = workspace_info.get("defaultLocationName")
             if default_lod is None:
                 default_lod = workspace_info.get("defaultLOD")
             if not namespaces:
@@ -416,10 +429,10 @@ def main():
         workspace_name = os.getenv('WB_WORKSPACE_NAME')
     if not workspace_owner_email:
         workspace_owner_email = os.getenv('WB_WORKSPACE_OWNER_EMAIL')
-    if not default_location:
-        default_location = os.getenv("WB_DEFAULT_LOCATION")
-    if not default_location_name:
-        default_location_name = os.getenv("WB_DEFAULT_LOCATION_NAME")
+    if not location_id:
+        location_id = os.getenv("WB_LOCATION_ID")
+    if not location_name:
+        location_name = os.getenv("WB_LOCATION_NAME")
     if not papi_url:
         papi_url = os.getenv('WB_PAPI_URL')
     if default_lod is None:
@@ -659,10 +672,10 @@ def main():
             request_data['workspaceName'] = workspace_name
         if workspace_owner_email:
             request_data['workspaceOwnerEmail'] = workspace_owner_email
-        if default_location:
-            request_data['defaultLocation'] = default_location
-        if default_location_name:
-            request_data['defaultLocationName'] = default_location_name
+        if location_id:
+            request_data['locationId'] = location_id
+        if location_name:
+            request_data['locationName'] = location_name
         if default_lod is not None:
             request_data['defaultLOD'] = default_lod
         if namespace_lods:

--- a/src/run.py
+++ b/src/run.py
@@ -256,6 +256,9 @@ def main():
                         help='On upload, how to merge conflicting SLXs; valid values are:\n'
                              '  "keep-existing": Use the existing content of the SLX from the repo\n'
                              '  "keep-uploaded": Use the uploaded content of the SLX')
+    parser.add_argument('--prune-stale-resources', action='store_true', dest='prune_stale_resources', default=False,
+                        help='On upload, prune from the repo any old/stale resources from previous uploads that\n'
+                             'are no longer active/valid in the current uploaded data.')
     parser.add_argument('--prune-stale-slxs', action='store_true', dest='prune_stale_slxs', default=False,
                         help='On upload, prune from the repo any old/stale SLXs from previous uploads that\n'
                              'are no longer active/valid in the current uploaded data.')
@@ -790,6 +793,7 @@ def main():
             "output": archive_text,
             "mergeMode": merge_mode,
             "pruneStaleSlxs": args.prune_stale_slxs,
+            "pruneStaleResources": args.prune_stale_resources,
             "message": "Updated workspace from map builder.",
             "finalizeAction": "mergeToMain",
         }

--- a/src/templates/common-labels.yaml
+++ b/src/templates/common-labels.yaml
@@ -1,8 +1,8 @@
     slx: {{slx_name}}
     workspace: {{workspace.short_name}}
-{% if default_location %}
-    defaultLocation: {{default_location}}
+{% if location_id %}
+    locationId: {{location_id}}
 {% endif %}
-{% if default_location_name %}
-    defaultLocationName: {{default_location_name}}
+{% if location_name %}
+    locationName: {{location_name}}
 {% endif %}

--- a/src/templates/workspace.yaml
+++ b/src/templates/workspace.yaml
@@ -4,6 +4,14 @@ metadata:
   name: {{workspace.short_name}}
   labels:
     workspace: {{workspace.short_name}}
+{% if location_id %}
+    locationId: {{location_id}}
+{% endif %}
+{% if location_name %}
+    locationName: {{location_name}}
+{% endif %}
+  annotations:
+    internal.runwhen.com/generated-by: "{{generated_by}}"
 spec:
   permissions:
   - user: {{workspace.owner_email}}


### PR DESCRIPTION
- old setting names were DEFAULT_LOCATION and DEFAULT_LOCATION_NAME
- new setting names are LOCATION_ID and LOCATION_NAME
- old label names were defaultLocation and defaultLocationName
- new label names are locationId and locationName
- there's still some backwards compatibility code to try to retrieve the settings with the old names from the info files if the new names don't exist. Hopefully we can remove that soon, though, when we're sure that everyone has migrated to the new names.
- also update the template for the workspace.yaml file to also include the location and generated-by labels/annotations to be consistent with what's in the generated SLX/workflow files.