### PR TITLE
basic map kustomization rule updates

### DIFF
--- a/.devcontainer.Dockerfile
+++ b/.devcontainer.Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.13.6-slim
+FROM python:3.13.7-slim
 
 # Create a non-root user `runwhen` to run commands
 ENV RUNWHEN_HOME=/home/runwhen
@@ -20,7 +20,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && rm -rf /usr/share/doc /usr/share/man /usr/share/info /var/cache/man
 
 # Install Terraform
-ENV TERRAFORM_VERSION=1.12.2
+ENV TERRAFORM_VERSION=1.13.3
 RUN wget https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip && \
     unzip terraform_${TERRAFORM_VERSION}_linux_amd64.zip terraform -d /usr/local/bin/ && \
     rm terraform_${TERRAFORM_VERSION}_linux_amd64.zip

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -20,7 +20,7 @@ ENV PYTHONUNBUFFERED=1 \
     PIP_DEFAULT_TIMEOUT=100 \
     POETRY_HOME="/opt/poetry" \
     # renovate: datasource=github-releases depName=python-poetry/poetry
-    POETRY_VERSION=2.1.4 \
+    POETRY_VERSION=2.2.1 \
     POETRY_VIRTUALENVS_IN_PROJECT=true \
     POETRY_NO_INTERACTION=1 \
     PYSETUP_PATH="/opt/pysetup" \

--- a/src/VERSION
+++ b/src/VERSION
@@ -1,4 +1,4 @@
 {
   "name": "runwhen-local",
-  "version": "0.10.25"
+  "version": "0.10.26"
 }

--- a/src/map-customization-rules/flux-kustomizations.yaml
+++ b/src/map-customization-rules/flux-kustomizations.yaml
@@ -6,5 +6,11 @@ spec:
         type: pattern
         matchType: base-name
         pattern: "flux-kstmz"
-        matchMode: substring
+        matchMode: exact
+      group: "{{namespace.name}} ({{cluster.name}})"
+    - match:
+        type: pattern
+        matchType: base-name
+        pattern: "fluxcd-reconciliation"
+        matchMode: exact
       group: "{{namespace.name}} ({{cluster.name}})"

--- a/src/map-customization-rules/namespace-based-rules.yaml
+++ b/src/map-customization-rules/namespace-based-rules.yaml
@@ -101,6 +101,12 @@ spec:
     - match:
         type: pattern
         matchType: base-name
+        pattern: "postgres-operations"
+        matchMode: exact
+      group: "{{namespace.name}} ({{cluster.name}})"
+    - match:
+        type: pattern
+        matchType: base-name
         pattern: "postgres-health"
         matchMode: exact
       group: "{{namespace.name}} ({{cluster.name}})"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Updates map customization rules (flux exact matches, new postgres-operations) and bumps Python/Terraform/Poetry with version 0.10.26.
> 
> - **Rules**:
>   - `src/map-customization-rules/flux-kustomizations.yaml`: set `flux-kstmz` `matchMode` to `exact`; add exact rule for `fluxcd-reconciliation`.
>   - `src/map-customization-rules/namespace-based-rules.yaml`: add exact rule for `postgres-operations`.
> - **Devcontainer**:
>   - `.devcontainer.Dockerfile`: bump base Python to `3.13.7-slim` and Terraform to `1.13.3`.
> - **Build**:
>   - `src/Dockerfile`: bump Poetry to `2.2.1`.
> - **Version**:
>   - `src/VERSION`: update to `0.10.26`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 804a68121a0f0c3fa671fc3f02aa8e4359ca02dc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->