### PR TITLE
Update name sanitization and version bump to 0.10.28

### DIFF
--- a/src/VERSION
+++ b/src/VERSION
@@ -1,4 +1,4 @@
 {
   "name": "runwhen-local",
-  "version": "0.10.27"
+  "version": "0.10.28"
 }

--- a/src/name_utils.py
+++ b/src/name_utils.py
@@ -23,10 +23,11 @@ def split_camel_cased_name(name: str) -> list[str]:
 def sanitize_name(name: str) -> str:
     """
     Remove or replace characters that are unsuitable for file names.
+    Also strips leading and trailing dashes to ensure RFC 1123 compliance.
     :param name: The name to sanitize.
     :return: The sanitized name.
     """
-    return name.replace(':', '-').replace('/', '-')
+    return name.replace(':', '-').replace('/', '-').strip('-')
 
 def remove_vowels(name: str, keep_first_letter: bool) -> str:
     """


### PR DESCRIPTION
- Enhance `sanitize_name` function to strip leading and trailing dashes for RFC 1123 compliance.
- Bump version from 0.10.27 to 0.10.28.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Strip leading/trailing dashes in sanitize_name for RFC 1123 compliance and bump version to 0.10.28.
> 
> - **Utilities**:
>   - Update `sanitize_name` in `src/name_utils.py` to strip leading/trailing dashes for RFC 1123 compliance.
> - **Release**:
>   - Bump `src/VERSION` from `0.10.27` to `0.10.28`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 57c062088bf672e326687a94cdfec762c1cdc4ad. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->