### PR TITLE
fix: cluster-level SLX resourcePath duplication (RW-430)

### DIFF
--- a/.cursor/rules/template-tags-hierarchy.mdc
+++ b/.cursor/rules/template-tags-hierarchy.mdc
@@ -25,6 +25,16 @@ The hierarchy ALWAYS ends with `resource_name`. `resource_type` NEVER appears
 in the hierarchy. Non-qualifier details (like `location`) are tags only, not
 hierarchy entries.
 
+### Parent inclusion rule
+
+A scope entry appears in the hierarchy ONLY when a more-specific qualifier
+exists. This prevents a parent from duplicating `resource_name`:
+- GCP: `project_id` only when `qualifiers.resource is defined`
+- K8s: `cluster` when `resource` or `namespace` exists; `namespace` only when `resource` exists
+- AWS: `account_name` when `resource` or `region` exists; `region` only when `resource` exists
+- Azure ARM: `subscription_name` when `resource` or `resource_group` exists; `resource_group` only when `resource` exists
+- Azure DevOps: `organization` when `resource` or `project` exists; `project` only when `resource` exists
+
 ### Leaf entry rule
 
 ```jinja

--- a/.cursor/rules/template-tags-hierarchy.mdc
+++ b/.cursor/rules/template-tags-hierarchy.mdc
@@ -33,7 +33,7 @@ exists. This prevents a parent from duplicating `resource_name`:
 - K8s: `cluster` when `resource` or `namespace` exists; `namespace` only when `resource` exists
 - AWS: `account_name` when `resource` or `region` exists; `region` only when `resource` exists
 - Azure ARM: `subscription_name` when `resource` or `resource_group` exists; `resource_group` only when `resource` exists
-- Azure DevOps: `organization` when `resource` or `project` exists; `project` only when `resource` exists
+- Azure DevOps: `organization` when `project` qualifier exists, or when `resource` exists and the match is not `organization`; `project` only when `resource` exists and the match is neither `organization` nor `project` (mirrors `azure-tags.yaml`)
 
 ### Leaf entry rule
 

--- a/docs/tag-hierarchy-contract.md
+++ b/docs/tag-hierarchy-contract.md
@@ -47,8 +47,13 @@ more specific than it. This prevents duplication between a parent entry and
 | AWS | `region` | `resource` |
 | Azure ARM | `subscription_name` | `resource` or `resource_group` |
 | Azure ARM | `resource_group` | `resource` |
-| Azure DevOps | `organization` | `resource` or `project` |
-| Azure DevOps | `project` | `resource` |
+| Azure DevOps | `organization` | `project`, or `resource` when the match is **not** `organization` |
+| Azure DevOps | `project` | `resource` when the match is **not** `organization` or `project` |
+
+For Azure DevOps, `match_resource.resource_type.name` gates parents so an
+organization-scoped SLX does not list `organization` twice, and a project-
+scoped SLX does not list `project` when `resource_name` is already the
+project (see `azure-tags.yaml` for the same `organization` guard).
 | Kubernetes | `cluster` | `resource` or `namespace` |
 | Kubernetes | `namespace` | `resource` |
 

--- a/docs/tag-hierarchy-contract.md
+++ b/docs/tag-hierarchy-contract.md
@@ -29,22 +29,30 @@ Each hierarchy template produces an ordered YAML list:
 platform → parent scopes → resource_name
 ```
 
-The hierarchy **always** ends with `resource_name`. The parent scopes are
-qualifier-derived context tags (cluster, namespace, project_id, etc.).
-Non-qualifier details like `location` or `region` are **not** included in the
-hierarchy — they exist only as informational tags.
+The hierarchy **always** ends with `resource_name`. Parent scopes appear
+**only when a more-specific qualifier exists** — a scope is never both a
+parent entry and the `resource_name`. Non-qualifier details like `location`
+are **not** included in the hierarchy — they exist only as informational tags.
 
-**Examples by platform:**
+### 2.2 Parent Inclusion Rule
 
-| Platform | Parent scopes | Leaf |
-|----------|--------------|------|
-| GCP | `project_id` (only when resource-scoped) | `resource_name` |
-| AWS | `account_name`, `region` | `resource_name` |
-| Azure ARM | `subscription_name`, `resource_group` | `resource_name` |
-| Azure DevOps | `organization`, `project` | `resource_name` |
-| Kubernetes | `cluster`, `namespace` | `resource_name` |
+A scope entry appears in the hierarchy **only** when there is a qualifier
+more specific than it. This prevents duplication between a parent entry and
+`resource_name`:
 
-### 2.2 Leaf Entry Rule
+| Platform | Parent scope | Included when qualifier exists |
+|----------|-------------|-------------------------------|
+| GCP | `project_id` | `resource` |
+| AWS | `account_name` | `resource` or `region` |
+| AWS | `region` | `resource` |
+| Azure ARM | `subscription_name` | `resource` or `resource_group` |
+| Azure ARM | `resource_group` | `resource` |
+| Azure DevOps | `organization` | `resource` or `project` |
+| Azure DevOps | `project` | `resource` |
+| Kubernetes | `cluster` | `resource` or `namespace` |
+| Kubernetes | `namespace` | `resource` |
+
+### 2.3 Leaf Entry Rule
 
 The last entry in the hierarchy is **always** `resource_name`:
 
@@ -55,21 +63,21 @@ The last entry in the hierarchy is **always** `resource_name`:
 There is no conditional — `resource_name` is unconditionally the leaf of
 every hierarchy. `resource_type` never appears in the hierarchy.
 
-### 2.3 Resulting Paths
+### 2.4 Resulting Paths
 
 | Scope | Example qualifiers | resource_name value | resourcePath |
 |-------|-------------------|-------------------|-------------|
 | Resource (GCP) | `["resource", "project"]` | `my-bucket` | `gcp/my-project/my-bucket` |
 | Project (GCP) | `["project"]` | `my-project` | `gcp/my-project` |
-| Namespace (K8s) | `["namespace", "cluster"]` | `online-boutique-dev` | `kubernetes/sandbox-cluster-1/online-boutique-dev/online-boutique-dev` |
-| Cluster (K8s) | `["cluster"]` | `sandbox-cluster-1` | `kubernetes/sandbox-cluster-1/sandbox-cluster-1` |
 | Resource (K8s) | `["resource", "namespace", "cluster"]` | `my-pod` | `kubernetes/my-cluster/default/my-pod` |
-| Resource Group (Azure) | `["resource_group", "subscription_name"]` | `my-rg` | `azure/my-sub/my-rg` |
+| Namespace (K8s) | `["namespace", "cluster"]` | `online-boutique-dev` | `kubernetes/sandbox-cluster-1/online-boutique-dev` |
+| Cluster (K8s) | `["cluster"]` | `sandbox-cluster-1` | `kubernetes/sandbox-cluster-1` |
+| Resource (AWS) | `["resource", "region", "account_name"]` | `my-bucket` | `aws/my-account/us-east-1/my-bucket` |
+| Region (AWS) | `["region", "account_name"]` | `us-east-1` | `aws/my-account/us-east-1` |
+| Account (AWS) | `["account_name"]` | `my-account` | `aws/my-account` |
 | Resource (Azure) | `["resource", "resource_group", "subscription_name"]` | `my-vm` | `azure/my-sub/my-rg/my-vm` |
-
-**Note:** Duplication in the path is expected and intentional. For example,
-a namespace-scoped K8s SLX has `online-boutique-dev` appearing twice — once
-as the `namespace` parent and once as `resource_name`. This is by design.
+| Resource Group (Azure) | `["resource_group", "subscription_name"]` | `my-rg` | `azure/my-sub/my-rg` |
+| Subscription (Azure) | `["subscription_name"]` | `my-sub` | `azure/my-sub` |
 
 ---
 

--- a/src/templates/aws-hierarchy.yaml
+++ b/src/templates/aws-hierarchy.yaml
@@ -1,6 +1,10 @@
     hierarchy: 
     - platform
+{% if qualifiers and (qualifiers.resource is defined or qualifiers.region is defined) %}
     - account_name
+{% endif %}
+{% if qualifiers and qualifiers.resource is defined %}
     - region
+{% endif %}
     - resource_name
 

--- a/src/templates/azure-hierarchy.yaml
+++ b/src/templates/azure-hierarchy.yaml
@@ -1,11 +1,15 @@
     hierarchy: 
     - platform
 {% if organization is defined %}
-    {# Azure DevOps resources #}
-{% if qualifiers and (qualifiers.resource is defined or qualifiers.project is defined) %}
+    {# Azure DevOps resources — mirror azure-tags.yaml: do not emit organization
+       as parent when the match IS an organization; do not emit project as parent
+       when the match IS organization or project (avoids duplicating resource_name). #}
+{% if qualifiers and qualifiers.project is defined %}
+    - organization
+{% elif qualifiers and qualifiers.resource is defined and match_resource.resource_type.name != 'organization' %}
     - organization
 {% endif %}
-{% if qualifiers and qualifiers.resource is defined %}
+{% if qualifiers and qualifiers.resource is defined and match_resource.resource_type.name not in ('organization', 'project') %}
     - project
 {% endif %}
 {% else %}

--- a/src/templates/azure-hierarchy.yaml
+++ b/src/templates/azure-hierarchy.yaml
@@ -2,21 +2,25 @@
     - platform
 {% if organization is defined %}
     {# Azure DevOps resources #}
-{% if qualifiers and qualifiers.project is defined %}
+{% if qualifiers and (qualifiers.resource is defined or qualifiers.project is defined) %}
     - organization
+{% endif %}
+{% if qualifiers and qualifiers.resource is defined %}
     - project
-{% elif qualifiers and qualifiers.resource and match_resource.resource_type.name != 'organization' %}
-    - organization
 {% endif %}
 {% else %}
     {# Azure ARM resources #}
+{% if qualifiers and (qualifiers.resource is defined or qualifiers.resource_group is defined) %}
 {% if subscription_name is defined %}
     - subscription_name
 {% else %}
     - subscription_id
 {% endif %}
+{% endif %}
+{% if qualifiers and qualifiers.resource is defined %}
 {% if resource_group is defined or (match_resource.resource_group is defined and match_resource.resource_group.name is defined) %}
     - resource_group
+{% endif %}
 {% endif %}
 {% endif %}
     - resource_name

--- a/src/templates/kubernetes-hierarchy.yaml
+++ b/src/templates/kubernetes-hierarchy.yaml
@@ -1,6 +1,6 @@
     hierarchy: 
     - platform
-{% if cluster.cluster_type | default('') == "aks" %}
+{% if cluster.cluster_type | default('') == "aks" and qualifiers and (qualifiers.resource is defined or qualifiers.namespace is defined or qualifiers.cluster is defined) %}
 {% if subscription_name is defined %}
     - subscription_name
 {% else %}
@@ -10,10 +10,10 @@
     - resource_group
 {% endif %}
 {% endif %}
-{% if cluster.name %}
+{% if cluster.name and qualifiers and (qualifiers.resource is defined or qualifiers.namespace is defined) %}
     - cluster
 {% endif %}
-{% if match_resource.namespace %}
+{% if match_resource.namespace and qualifiers and qualifiers.resource is defined %}
     - namespace
 {% endif %}
     - resource_name


### PR DESCRIPTION
## Linear

Addresses [RW-430 — cluster-level SLX resource paths are duplicated](https://linear.app/runwhen/issue/RW-430/cluster-level-slx-resource-paths-are-duplicated).

## Problem

For Kubernetes (and similarly AWS / Azure) group-scoped SLXs, the hierarchy listed both a **parent** scope and **`resource_name`** when they represented the same logical scope. Example: cluster-scoped SLX with qualifiers `{cluster: controlplane-cluster}` produced `resourcePath`: `kubernetes/controlplane-cluster/controlplane-cluster`.

## Root cause

`resource_name` follows the platform specificity chain (e.g. K8s: `resource` > `namespace` > `cluster`). For a cluster-scoped SLX, `resource_name` **is** the cluster. The hierarchy template still emitted `cluster` whenever `cluster.name` was set, duplicating the segment.

## Fix (this PR)

**Parent inclusion rule:** emit a scope in the hierarchy only when a **more-specific** qualifier exists (same idea as GCP’s `project_id` only when `resource` is qualified).

- **Kubernetes:** `cluster` only if `resource` or `namespace` qualifier exists; `namespace` only if `resource` exists.
- **AWS:** `account_name` if `resource` or `region`; `region` only if `resource`.
- **Azure ARM:** subscription parent if `resource` or `resource_group`; `resource_group` only if `resource`.
- **Azure DevOps:** `organization` if `resource` or `project`; `project` only if `resource`.

**Expected cluster-scoped K8s path:** `kubernetes/<cluster>`.

## Scope / cleanup

This branch was rebased onto current `main` as **one commit**. Dropped from the old `tag/fixes` tip: `src/VERSION` bumps and the unrelated `merge_to_main.yaml` deployment-name tweak. Other template/renderer work already lives on `main`; this PR is only hierarchy + contract docs.

## Files

- `src/templates/kubernetes-hierarchy.yaml`, `aws-hierarchy.yaml`, `azure-hierarchy.yaml`
- `docs/tag-hierarchy-contract.md`, `.cursor/rules/template-tags-hierarchy.mdc`

## Testing

Re-render a workspace; cluster-scoped SLXs should no longer duplicate the cluster in `resourcePath`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes hierarchy emission for AWS/Azure/Kubernetes, which will alter generated `resourcePath` values for group-scoped SLXs and could impact any downstream consumers expecting the previous (duplicated) paths.
> 
> **Overview**
> Updates AWS, Azure (ARM + DevOps), and Kubernetes hierarchy templates to **only emit parent scope segments when a more-specific qualifier exists**, preventing cases where a parent entry duplicates `resource_name` (e.g., cluster/account/subscription-level SLXs).
> 
> Refreshes the hierarchy contract docs (and Cursor rule) to formalize this *parent inclusion rule*, adds clarified examples of resulting paths, and documents Azure DevOps-specific guards using `match_resource.resource_type.name`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 95fbb32aab43204b0bf3f6234d26a46dff916198. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->