### PR TITLE
feat(k8s): index Jobs and CronJobs

### DIFF
--- a/src/VERSION
+++ b/src/VERSION
@@ -1,4 +1,4 @@
 {
   "name": "runwhen-local",
-  "version": "0.10.55"
+  "version": "0.10.56"
 }

--- a/src/indexers/kubeapi.py
+++ b/src/indexers/kubeapi.py
@@ -1,7 +1,7 @@
 """
 Index assets that we can find by querying K8s API servers
 to fetch live clusters, Namespaces, Ingresses, Services,
-Deployments, StatefulSets, etc.
+Deployments, StatefulSets, Jobs, CronJobs, etc.
 
 Recently updated to support anotations/label discovery, readded robvs comments
 where possible. 
@@ -887,6 +887,38 @@ def index(component_context: Context):
                                                                     app_attributes)
                                 except ApiException as e:
                                     logger.debug(f"Error scanning for deployment instances; skipping and continuing; error: {e}")
+
+                            #
+                            # Index Jobs and CronJobs (batch/v1)
+                            #
+                            batch_api_client = client.BatchV1Api(api_client=api_client)
+                            batch_info = (
+                                ('Job', batch_api_client.list_namespaced_job, KubernetesResourceType.JOB, kubeapi_parsers.parse_app),
+                                ('CronJob', batch_api_client.list_namespaced_cron_job, KubernetesResourceType.CRON_JOB, kubeapi_parsers.parse_cronjob),
+                            )
+                            for batch_kind, batch_list_method, batch_resource_type, parse_batch_resource in batch_info:
+                                try:
+                                    ret = batch_list_method(namespace_name)
+                                    for raw_resource in ret.items:
+                                        if (include_annotations or include_labels) and not has_included_annotations_or_labels(raw_resource, include_annotations, include_labels):
+                                            continue
+                                        if has_excluded_annotations_or_labels(raw_resource, exclude_annotations, exclude_labels):
+                                            continue
+                                        owner_name = extract_owner_name(raw_resource)
+                                        batch_name = raw_resource.metadata.name
+                                        batch_qualified_name = get_qualified_name(namespace_qualified_name, batch_name)
+                                        batch_attributes = parse_batch_resource(raw_resource)
+                                        batch_attributes['kind'] = batch_kind
+                                        batch_attributes['namespace'] = namespace
+                                        if owner_name:
+                                            batch_attributes['owner'] = owner_name
+                                        registry.add_resource(KUBERNETES_PLATFORM,
+                                                              batch_resource_type.value,
+                                                              batch_name,
+                                                              batch_qualified_name,
+                                                              batch_attributes)
+                                except ApiException as e:
+                                    logger.debug(f"Error scanning for {batch_kind} instances; skipping and continuing; error: {e}")
 
                             #
                             # Index the namespace ingresses

--- a/src/indexers/kubeapi_parsers.py
+++ b/src/indexers/kubeapi_parsers.py
@@ -77,9 +77,25 @@ def parse_namespace(resource):
 
 
 def parse_app(resource):
-    """ Used for Deployments, StatefulSets, DaemonSets and Jobs"""
+    """Used for Deployments, StatefulSets, DaemonSets, and Jobs (pod template under spec.template)."""
     ret = parse_namespaced_resource(resource)
-    template_labels = resource.spec.template.metadata.labels
+    meta = resource.spec.template.metadata
+    template_labels = meta.labels if meta and meta.labels else {}
+    for k, v in template_labels.items():
+        fqk = f"template/{k}"
+        ret[f"{kube_escape(fqk)}"] = v
+    return ret
+
+
+def parse_cronjob(resource):
+    """CronJob pod template lives under spec.job_template.spec.template."""
+    ret = parse_namespaced_resource(resource)
+    try:
+        tmpl = resource.spec.job_template.spec.template
+        meta = tmpl.metadata
+        template_labels = meta.labels if meta and meta.labels else {}
+    except (AttributeError, TypeError):
+        template_labels = {}
     for k, v in template_labels.items():
         fqk = f"template/{k}"
         ret[f"{kube_escape(fqk)}"] = v

--- a/src/indexers/kubetypes.py
+++ b/src/indexers/kubetypes.py
@@ -24,6 +24,8 @@ class KubernetesResourceType(Enum):
     DEPLOYMENT = "deployment"
     DAEMON_SET = "daemonset"
     STATEFUL_SET = "statefulset"
+    JOB = "job"
+    CRON_JOB = "cronjob"
     INGRESS = "ingress"
     SERVICE = "service"
     POD = "pod"


### PR DESCRIPTION
## Summary
- Index **Job** and **CronJob** resources in each discovered namespace via `BatchV1Api` (`list_namespaced_job`, `list_namespaced_cron_job`), matching existing annotation/label filters and registry wiring used for Deployments.
- Add `KubernetesResourceType.JOB` (`job`) and `KubernetesResourceType.CRON_JOB` (`cronjob`) so generation rules can target these types.
- Add `parse_cronjob` for pod template labels under `spec.job_template.spec.template`; tighten `parse_app` template label handling for nil metadata.
- Bump `src/VERSION` to **0.10.55**.

## Notes
Cluster RBAC must allow `batch` `jobs` and `cronjobs` `get,list,watch` where discovery runs (some test stacks already merge a batch ClusterRole).

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new Kubernetes API discovery calls and resource types, which may impact RBAC/permissions behavior and increase indexing surface area. Failures are caught and logged, but mis-parsing or unexpected API shapes could affect discovery output.
> 
> **Overview**
> Extends Kubernetes indexing to also discover `batch/v1` **Jobs** and **CronJobs** per namespace, applying the same include/exclude annotation/label filtering and registering them as first-class resources.
> 
> Adds new `KubernetesResourceType` values (`JOB`, `CRON_JOB`) and updates parsing to safely extract pod-template labels for Jobs (nil-safe `spec.template.metadata`) and CronJobs (from `spec.job_template.spec.template`).
> 
> Bumps `src/VERSION` from `0.10.55` to `0.10.56`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 39540931e999efc94e5e692ef18a0d419c9203b5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->