### PR TITLE
feat(run.sh): honor DISABLE_CLOUDQUERY from environment variables

### DIFF
--- a/src/VERSION
+++ b/src/VERSION
@@ -1,4 +1,4 @@
 {
   "name": "runwhen-local",
-  "version": "0.10.56"
+  "version": "0.10.57"
 }

--- a/src/run.sh
+++ b/src/run.sh
@@ -3,7 +3,8 @@
 # Path to the lock file
 TMPDIR=${TMPDIR:-/tmp}
 LOCK_FILE="$TMPDIR/.wb_lock"
-DISABLE_CLOUDQUERY=0
+# Honor DISABLE_CLOUDQUERY from the environment (e.g. Helm extraEnv); --disable-cloudquery still sets it below
+DISABLE_CLOUDQUERY=${DISABLE_CLOUDQUERY:-0}
 
 # Parse arguments
 POSITIONAL_ARGS=()


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Small startup-script change that only affects which pipeline components run; no auth, data, or security logic touched.
> 
> **Overview**
> **runwhen-local** is bumped to **0.10.57**, and **`run.sh`** now respects a pre-set **`DISABLE_CLOUDQUERY`** environment variable (for example via Helm `extraEnv`) instead of always resetting it to `0` at startup.
> 
> The **`--disable-cloudquery`** CLI flag still forces CloudQuery off by setting the variable to `1` during argument parsing, so behavior for explicit CLI use is unchanged while container/orchestrator configuration can disable CloudQuery without extra flags.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6892d55347146549170961643e11968354849626. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->