### PR TITLE
Fix gcp-auth template for file-style K8s SA secrets

### DIFF
--- a/docs/user-guide/cloud-discovery/gcp-extras-2.md
+++ b/docs/user-guide/cloud-discovery/gcp-extras-2.md
@@ -144,19 +144,30 @@ See [GCP Discovery → GKE Cluster Discovery](gcp.md#gke-cluster-discovery).
 ### Template Usage
 
 #### GCP Authentication Template (`gcp-auth.yaml`)
+
+Priority order:
+
+1. **`custom.gcp_credentials_key`** — platform workspace secret (e.g. `ops-suite-sa`)
+2. **`secrets.gcp_service_account`** — alternate workspace secret mapping
+3. **`gcp_service_account_secret` auth** (`cloudConfig.gcp.saSecretName`) — split K8s secret keys `projectId` + `serviceAccountKey`
+4. **File-style K8s secret** — when discovery uses `applicationCredentialsFile` and `custom.gcp_service_account_secret_name` is set:
+
 ```yaml
-{% if cluster.cluster_type == "gke" and cluster.auth_type == "gcp_service_account" %}
-    - name: gcp_credentials
-      workspaceKey: gcp:sa@cli
-    - name: gcp_projectId
-      workspaceKey: k8s:file@secret/{{ custom.gcp_service_account_secret_name }}:projectId
-    - name: gcp_serviceAccountKey
-      workspaceKey: k8s:file@secret/{{ custom.gcp_service_account_secret_name }}:serviceAccountKey
-{% elif cluster.auth_type == "gcp_adc" %}
-    - name: gcp_credentials
-      workspaceKey: gcp:adc@cli
-{% endif %}
+custom:
+  gcp_service_account_secret_name: gcp-sa
+  # optional; defaults to secret name when omitted
+  gcp_service_account_secret_key: gcp-sa
 ```
+
+Generated `secretsProvided`:
+
+```yaml
+- name: gcp_credentials
+  workspaceKey: k8s:file@secret/gcp-sa:gcp-sa
+```
+
+5. **`gcp_adc`** — `gcp:adc@cli` only
+6. **`gcp_service_account` without secret name** — `gcp:sa@cli` fallback
 
 #### GKE Kubernetes Authentication Template (`gcp-kubernetes-auth.yaml`)
 ```yaml

--- a/src/VERSION
+++ b/src/VERSION
@@ -1,4 +1,4 @@
 {
   "name": "runwhen-local",
-  "version": "0.11.0"
+  "version": "0.11.1"
 }

--- a/src/templates/gcp-auth.yaml
+++ b/src/templates/gcp-auth.yaml
@@ -1,10 +1,9 @@
-{% if cluster is defined and cluster.cluster_type | default('') == "gke" and cluster.auth_type | default('') == "gcp_service_account" %}
+{% if custom is defined and custom.gcp_credentials_key is defined %}
     - name: gcp_credentials
-      workspaceKey: gcp:sa@cli
-    - name: gcp_projectId
-      workspaceKey: k8s:file@secret/{{ custom.gcp_service_account_secret_name | default('undefined') }}:projectId
-    - name: gcp_serviceAccountKey
-      workspaceKey: k8s:file@secret/{{ custom.gcp_service_account_secret_name | default('undefined') }}:serviceAccountKey
+      workspaceKey: "{{ custom.gcp_credentials_key }}"
+{% elif secrets is defined and secrets.gcp_service_account is defined %}
+    - name: gcp_credentials
+      workspaceKey: "{{ secrets.gcp_service_account }}"
 {% elif cluster is defined and cluster.cluster_type | default('') == "gke" and cluster.auth_type | default('') == "gcp_service_account_secret" %}
     - name: gcp_credentials
       workspaceKey: gcp:sa@cli
@@ -12,13 +11,6 @@
       workspaceKey: k8s:file@secret/{{ cluster.auth_secret | default('undefined') }}:projectId
     - name: gcp_serviceAccountKey
       workspaceKey: k8s:file@secret/{{ cluster.auth_secret | default('undefined') }}:serviceAccountKey
-{% elif match_resource is defined and match_resource.auth_type | default('') == "gcp_service_account" %}
-    - name: gcp_credentials
-      workspaceKey: gcp:sa@cli
-    - name: gcp_projectId
-      workspaceKey: k8s:file@secret/{{ custom.gcp_service_account_secret_name | default('undefined') }}:projectId
-    - name: gcp_serviceAccountKey
-      workspaceKey: k8s:file@secret/{{ custom.gcp_service_account_secret_name | default('undefined') }}:serviceAccountKey
 {% elif match_resource is defined and match_resource.auth_type | default('') == "gcp_service_account_secret" %}
     - name: gcp_credentials
       workspaceKey: gcp:sa@cli
@@ -32,13 +24,20 @@
 {% elif cluster is defined and cluster.cluster_type | default('') == "gke" and cluster.auth_type | default('') == "gcp_adc" %}
     - name: gcp_credentials
       workspaceKey: gcp:adc@cli
-{% elif custom is defined and custom.gcp_credentials_key is defined %}
+{% elif custom is defined and custom.gcp_service_account_secret_name | default('') != '' and (
+       (cluster is defined and cluster.cluster_type | default('') == "gke" and cluster.auth_type | default('') == "gcp_service_account") or
+       (match_resource is defined and match_resource.auth_type | default('') == "gcp_service_account")
+     ) %}
+    {% set gcp_sa_key = custom.gcp_service_account_secret_key | default(custom.gcp_service_account_secret_name) %}
     - name: gcp_credentials
-      workspaceKey: "{{ custom.gcp_credentials_key }}"
-{% elif secrets is defined and secrets.gcp_service_account is defined %}
+      workspaceKey: k8s:file@secret/{{ custom.gcp_service_account_secret_name }}:{{ gcp_sa_key }}
+{% elif cluster is defined and cluster.cluster_type | default('') == "gke" and cluster.auth_type | default('') == "gcp_service_account" %}
     - name: gcp_credentials
-      workspaceKey: "{{ secrets.gcp_service_account }}"
+      workspaceKey: gcp:sa@cli
+{% elif match_resource is defined and match_resource.auth_type | default('') == "gcp_service_account" %}
+    - name: gcp_credentials
+      workspaceKey: gcp:sa@cli
 {% else %}
     - name: gcp_credentials
       workspaceKey: GCP AUTH DETAILS NOT FOUND
-{% endif %} 
+{% endif %}

--- a/src/templates/gcp-kubernetes-auth.yaml
+++ b/src/templates/gcp-kubernetes-auth.yaml
@@ -1,24 +1,20 @@
-{% if cluster is defined and cluster.cluster_type | default('') == "gke" and cluster.auth_type | default('') == "gcp_service_account" %}
-    - name: kubeconfig
-      workspaceKey: gcp:sa@kubeconfig:{{ cluster.name | default('undefined') }}/{{ cluster.zone | default(cluster.region | default('undefined')) }}
-    - name: gcp_projectId
-      workspaceKey: k8s:file@secret/{{ custom.gcp_service_account_secret_name | default('undefined') }}:projectId
-    - name: gcp_serviceAccountKey
-      workspaceKey: k8s:file@secret/{{ custom.gcp_service_account_secret_name | default('undefined') }}:serviceAccountKey
-{% elif cluster is defined and cluster.cluster_type | default('') == "gke" and cluster.auth_type | default('') == "gcp_service_account_secret" %}
+{% if cluster is defined and cluster.cluster_type | default('') == "gke" and cluster.auth_type | default('') == "gcp_service_account_secret" %}
     - name: kubeconfig
       workspaceKey: gcp:sa@kubeconfig:{{ cluster.name | default('undefined') }}/{{ cluster.zone | default(cluster.region | default('undefined')) }}
     - name: gcp_projectId
       workspaceKey: k8s:file@secret/{{ cluster.auth_secret | default('undefined') }}:projectId
     - name: gcp_serviceAccountKey
       workspaceKey: k8s:file@secret/{{ cluster.auth_secret | default('undefined') }}:serviceAccountKey
+{% elif cluster is defined and cluster.cluster_type | default('') == "gke" and cluster.auth_type | default('') == "gcp_service_account" %}
+    - name: kubeconfig
+      workspaceKey: gcp:sa@kubeconfig:{{ cluster.name | default('undefined') }}/{{ cluster.zone | default(cluster.region | default('undefined')) }}
 {% elif cluster is defined and cluster.cluster_type | default('') == "gke" and cluster.auth_type | default('') == "gcp_adc" %}
     - name: kubeconfig
       workspaceKey: gcp:adc@kubeconfig:{{ cluster.name | default('undefined') }}/{{ cluster.zone | default(cluster.region | default('undefined')) }}
 {% elif custom is defined and custom.kubeconfig_secret_name | default('') != '' %}
     - name: kubeconfig
-      workspaceKey: k8s:file@secret/{{ custom.kubeconfig_secret_name }}:kubeconfig
+      workspaceKey: {{ custom.kubeconfig_secret_name | default('undefined') }}
 {% else %}
     - name: kubeconfig
       workspaceKey: GKE AUTH DETAILS NOT FOUND
-{% endif %} 
+{% endif %}


### PR DESCRIPTION
## Summary
- Prefer `custom.gcp_credentials_key` (platform workspace secrets) before auth-type branches in `gcp-auth.yaml`
- For `applicationCredentialsFile` discovery (`gcp_service_account` auth), emit a single `gcp_credentials` ref as `k8s:file@secret/{name}:{key}` instead of bogus `projectId` / `serviceAccountKey` split keys
- Preserve existing `saSecretName` split-key behavior for `gcp_service_account_secret` auth
- Drop split keys from `gcp-kubernetes-auth.yaml` file-auth branch; fix `kubeconfig_secret_name` to accept full workspace keys

## Test plan
- [ ] Re-run workspace-builder discovery with `applicationCredentialsFile` + `custom.gcp_service_account_secret_name: gcp-sa`
- [ ] Verify generated GCP runbooks have `secretsProvided` with `k8s:file@secret/gcp-sa:gcp-sa` (or `gcp_credentials_key` when set)
- [ ] Verify `saSecretName`-based workspaces still get split `projectId` / `serviceAccountKey` refs


Made with [Cursor](https://cursor.com)