### PR TITLE
fix(kubeapi): scope-aware CRD discovery + missing import

### DIFF
--- a/src/VERSION
+++ b/src/VERSION
@@ -1,4 +1,4 @@
 {
   "name": "runwhen-local",
-  "version": "0.11.1"
+  "version": "0.11.2"
 }

--- a/src/enrichers/kubernetes.py
+++ b/src/enrichers/kubernetes.py
@@ -67,11 +67,14 @@ class KubernetesPlatformHandler(PlatformHandler):
     @staticmethod
     def get_common_resource_property_values(resource: Resource, qualifier_name: str) -> Optional[str]:
         if qualifier_name == "cluster":
-            return get_cluster(resource).name
+            cluster = get_cluster(resource)
+            return cluster.name if cluster else None
         elif qualifier_name == "context":
             return get_context(resource)
         elif qualifier_name == "namespace":
-            return get_namespace(resource).name
+            # Cluster-scoped custom resources have no owning namespace.
+            namespace = get_namespace(resource)
+            return namespace.name if namespace else None
         elif qualifier_name == "subscription_id":
             cluster = get_cluster(resource)
             if cluster:

--- a/src/enrichers/kubernetes.py
+++ b/src/enrichers/kubernetes.py
@@ -29,35 +29,34 @@ class KubernetesPlatformHandler(PlatformHandler):
                       context: Context) -> Sequence[Resource]:
         result = list()
         registry: Registry = context.get_property(REGISTRY_PROPERTY_NAME)
+
+        if resource_type_spec.resource_type_name == KubernetesResourceType.CUSTOM.value:
+            # Each CRD lives in its own registry bucket keyed by
+            # ``{plural}.{group}`` (see the custom-resource loop in
+            # ``indexers.kubeapi``). Look up that specific bucket instead of
+            # the coarse "custom" bucket -- no linear search or per-instance
+            # attribute filter is needed to disambiguate kinds any more.
+            lookup_name = f"{resource_type_spec.kind}.{resource_type_spec.group}"
+            resource_type = registry.lookup_resource_type(KUBERNETES_PLATFORM, lookup_name)
+            if not resource_type:
+                return result
+            check_version = (resource_type_spec.version is not None
+                             and resource_type_spec.version != '*')
+            for resource in resource_type.instances.values():
+                # Version pinning is still supported: the indexer stores each
+                # discovered version's resources under the same plural.group
+                # bucket, so callers that pin a specific version filter here.
+                if check_version and getattr(resource, "version", None) != resource_type_spec.version:
+                    continue
+                result.append(resource)
+            return result
+
+        # Non-custom (built-in) Kubernetes resource types.
         resource_type = registry.lookup_resource_type(KUBERNETES_PLATFORM, resource_type_spec.resource_type_name)
         if not resource_type:
             return result
-
         for resource in resource_type.instances.values():
-            if resource_type_spec.resource_type_name == KubernetesResourceType.CUSTOM.value:
-                # TODO: This isn't a super efficient implementation, especially if there are a lot of
-                # different custom resource types, because we do a linear search over the complete list of
-                # custom resources. Currently, there aren't a lot of custom resources that are indexed,
-                # so I don't think this will be a problem. But if it turns out to be a performance issue,
-                # it wouldn't be too hard to come up with some more efficient implementation, presumably
-                # one that structures the data more by the group/version/plural-name, so that we don't
-                # have to iterate over everything. Or, of course, switching back to some sort of actual
-                # database, preferably something that runs in-process, but I think it only makes sense
-                # to do that if there's some other compelling reason to want that, e.g. separating out
-                # the resource discovery process into a standalone service that supports more
-                # full-featured querying of the resources.
-                # NB: Use getattr here to avoid linting errors, since currently these attributes
-                # are set dynamically, so they're not known to do static type analysis.
-                # Should think about ways to make this more type-safe...
-                if getattr(resource, "plural_name") != resource_type_spec.kind:
-                    continue
-                if getattr(resource, "group") != resource_type_spec.group:
-                    continue
-                check_version = resource_type_spec.version is not None and resource_type_spec.version != '*'
-                if check_version and getattr(resource, "version") != resource_type_spec.version:
-                    continue
             result.append(resource)
-
         return result
 
     def get_level_of_detail(self, resource: Resource) -> LevelOfDetail:

--- a/src/enrichers/test_kubernetes_crd_lookup.py
+++ b/src/enrichers/test_kubernetes_crd_lookup.py
@@ -1,0 +1,198 @@
+"""Unit tests for the CRD-aware lookup in
+``enrichers.kubernetes.KubernetesPlatformHandler.get_resources``.
+
+These pin the change that made custom-resource discovery first-class:
+
+* Each CRD lives in its own registry bucket keyed by
+  ``{plural}.{group}`` (e.g. ``buckets.storage.gcp.upbound.io``) rather
+  than being lumped under the coarse ``"custom"`` bucket.
+* A generation rule whose spec resolves to ``resource_type_name ==
+  "custom"`` (the ``KubernetesResourceType.CUSTOM.value`` sentinel) is
+  routed to the specific bucket via ``{kind}.{group}`` \u2014 no
+  linear-search-and-filter pass over every discovered CRD instance.
+* Built-in Kubernetes types are untouched.
+* Version pinning still works when a rule pins ``plural.group/vX``.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from unittest import TestCase
+
+_THIS_DIR = os.path.dirname(os.path.abspath(__file__))
+_SRC_DIR = os.path.dirname(_THIS_DIR)
+if _SRC_DIR not in sys.path:
+    sys.path.insert(0, _SRC_DIR)
+
+from resources import Registry, REGISTRY_PROPERTY_NAME  # noqa: E402
+from enrichers.kubernetes import KubernetesPlatformHandler  # noqa: E402
+from indexers.kubetypes import (  # noqa: E402
+    KUBERNETES_PLATFORM,
+    KubernetesResourceType,
+    KubernetesResourceTypeSpec,
+)
+
+
+class _FakeContext:
+    """Minimal Context stand-in exposing only ``get_property``."""
+
+    def __init__(self, registry: Registry):
+        self._props = {REGISTRY_PROPERTY_NAME: registry}
+
+    def get_property(self, name):
+        return self._props.get(name)
+
+
+def _register_crd(registry: Registry, plural: str, group: str, version: str,
+                  name: str, qualified_name: str):
+    """Register a CRD instance under its per-CRD registry bucket, matching
+    what ``indexers.kubeapi`` does at index time."""
+    return registry.add_resource(
+        KUBERNETES_PLATFORM,
+        f"{plural}.{group}",
+        name,
+        qualified_name,
+        {
+            "plural_name": plural,
+            "group": group,
+            "version": version,
+            "kind": plural.rstrip("s").capitalize(),
+        },
+    )
+
+
+class GetResourcesForCustomTypeTest(TestCase):
+    def setUp(self):
+        self.registry = Registry()
+        self.handler = KubernetesPlatformHandler()
+
+    def _spec(self, plural: str, group: str, version=None):
+        return KubernetesResourceTypeSpec(
+            KUBERNETES_PLATFORM,
+            KubernetesResourceType.CUSTOM.value,
+            group,
+            version,
+            plural,
+        )
+
+    def test_returns_only_matching_crd_instances(self):
+        """A spec for ``buckets.storage.gcp.upbound.io`` returns the
+        Bucket instances but not the HelmRelease instances -- because
+        they live in different registry buckets, not because we filter
+        after the fetch."""
+        _register_crd(self.registry, "buckets", "storage.gcp.upbound.io",
+                      "v1beta2", "b1", "default/buckets.storage.gcp.upbound.io/b1")
+        _register_crd(self.registry, "buckets", "storage.gcp.upbound.io",
+                      "v1beta2", "b2", "default/buckets.storage.gcp.upbound.io/b2")
+        _register_crd(self.registry, "helmreleases", "helm.toolkit.fluxcd.io",
+                      "v2beta1", "hr1", "default/kube-system/helmreleases.helm.toolkit.fluxcd.io/hr1")
+
+        spec = self._spec("buckets", "storage.gcp.upbound.io")
+        resources = list(self.handler.get_resources(spec, _FakeContext(self.registry)))
+
+        self.assertEqual(sorted(r.name for r in resources), ["b1", "b2"])
+
+    def test_empty_result_for_unknown_crd(self):
+        """A spec pointing at a CRD that was never indexed returns [],
+        not an exception."""
+        _register_crd(self.registry, "buckets", "storage.gcp.upbound.io",
+                      "v1beta2", "b1", "default/buckets.storage.gcp.upbound.io/b1")
+
+        spec = self._spec("hmackeys", "storage.gcp.upbound.io")
+        resources = list(self.handler.get_resources(spec, _FakeContext(self.registry)))
+
+        self.assertEqual(resources, [])
+
+    def test_version_pinned_spec_filters_out_other_versions(self):
+        """A spec that pins a version returns only instances stored with
+        that version. This exercises the version-filter branch that
+        survived the refactor."""
+        _register_crd(self.registry, "buckets", "storage.gcp.upbound.io",
+                      "v1beta1", "b_v1", "default/buckets.storage.gcp.upbound.io/b_v1")
+        _register_crd(self.registry, "buckets", "storage.gcp.upbound.io",
+                      "v1beta2", "b_v2", "default/buckets.storage.gcp.upbound.io/b_v2")
+
+        spec = self._spec("buckets", "storage.gcp.upbound.io", version="v1beta2")
+        resources = list(self.handler.get_resources(spec, _FakeContext(self.registry)))
+
+        self.assertEqual([r.name for r in resources], ["b_v2"])
+
+    def test_star_version_matches_any(self):
+        """A spec that uses the wildcard version ``'*'`` returns every
+        registered instance regardless of version."""
+        _register_crd(self.registry, "buckets", "storage.gcp.upbound.io",
+                      "v1beta1", "b_v1", "default/buckets.storage.gcp.upbound.io/b_v1")
+        _register_crd(self.registry, "buckets", "storage.gcp.upbound.io",
+                      "v1beta2", "b_v2", "default/buckets.storage.gcp.upbound.io/b_v2")
+
+        spec = self._spec("buckets", "storage.gcp.upbound.io", version="*")
+        resources = list(self.handler.get_resources(spec, _FakeContext(self.registry)))
+
+        self.assertEqual(sorted(r.name for r in resources), ["b_v1", "b_v2"])
+
+    def test_unversioned_spec_matches_any_version(self):
+        """A spec that omits the version (the common case) also matches
+        every registered instance."""
+        _register_crd(self.registry, "buckets", "storage.gcp.upbound.io",
+                      "v1beta1", "b_v1", "default/buckets.storage.gcp.upbound.io/b_v1")
+        _register_crd(self.registry, "buckets", "storage.gcp.upbound.io",
+                      "v1beta2", "b_v2", "default/buckets.storage.gcp.upbound.io/b_v2")
+
+        spec = self._spec("buckets", "storage.gcp.upbound.io")
+        resources = list(self.handler.get_resources(spec, _FakeContext(self.registry)))
+
+        self.assertEqual(sorted(r.name for r in resources), ["b_v1", "b_v2"])
+
+    def test_builtin_kubernetes_type_lookup_is_unchanged(self):
+        """A spec for a built-in K8s resource type (e.g. ``deployment``)
+        still looks up that literal type name -- the CRD-lookup branch
+        must not steal built-in traffic."""
+        self.registry.add_resource(
+            KUBERNETES_PLATFORM, "deployment", "d1",
+            "default/kube-system/d1", {"cluster": "default"},
+        )
+        spec = KubernetesResourceTypeSpec(
+            KUBERNETES_PLATFORM,
+            KubernetesResourceType.DEPLOYMENT.value,
+            None, None, None,
+        )
+        resources = list(self.handler.get_resources(spec, _FakeContext(self.registry)))
+        self.assertEqual([r.name for r in resources], ["d1"])
+
+    def test_resource_type_name_field_is_the_crd_specific_bucket(self):
+        """Regression: each registered resource must expose
+        ``resource_type.name == "{plural}.{group}"`` so the
+        ``kubernetes-tags.yaml`` template surfaces the proper CRD type."""
+        _register_crd(self.registry, "buckets", "storage.gcp.upbound.io",
+                      "v1beta2", "b1", "default/buckets.storage.gcp.upbound.io/b1")
+        spec = self._spec("buckets", "storage.gcp.upbound.io")
+        [bucket] = self.handler.get_resources(spec, _FakeContext(self.registry))
+        self.assertEqual(bucket.resource_type.name, "buckets.storage.gcp.upbound.io")
+
+    def test_no_resource_type_custom_bucket_is_ever_looked_up(self):
+        """Sanity: even if some other CRD indexer erroneously wrote
+        instances under the legacy ``custom`` bucket, our lookup path
+        never touches that bucket for a CUSTOM spec. This documents the
+        new invariant."""
+        self.registry.add_resource(
+            KUBERNETES_PLATFORM,
+            KubernetesResourceType.CUSTOM.value,  # legacy bucket
+            "legacy",
+            "default/legacy",
+            {"plural_name": "buckets", "group": "storage.gcp.upbound.io"},
+        )
+        _register_crd(self.registry, "buckets", "storage.gcp.upbound.io",
+                      "v1beta2", "b1", "default/buckets.storage.gcp.upbound.io/b1")
+
+        spec = self._spec("buckets", "storage.gcp.upbound.io")
+        resources = list(self.handler.get_resources(spec, _FakeContext(self.registry)))
+        # Only the properly-registered resource comes back; the legacy
+        # bucket is ignored (the new lookup key is plural.group, not
+        # "custom").
+        self.assertEqual([r.name for r in resources], ["b1"])
+
+
+if __name__ == "__main__":
+    import unittest
+    unittest.main()

--- a/src/indexers/kubeapi.py
+++ b/src/indexers/kubeapi.py
@@ -41,7 +41,7 @@ from enrichers.generation_rules import RESOURCE_TYPE_SPECS_PROPERTY
 # Or something like that...
 from enrichers.generation_rule_types import LevelOfDetail
 from enrichers.generation_rules import DEFAULT_LOD_SETTING
-from .kubetypes import KUBERNETES_PLATFORM, KubernetesResourceType
+from .kubetypes import KUBERNETES_PLATFORM, KubernetesResourceType, KubernetesResourceTypeSpec
 from resources import Registry, REGISTRY_PROPERTY_NAME
 from . import kubeapi_parsers
 from .common import CLOUD_CONFIG_SETTING
@@ -87,6 +87,65 @@ class GroupVersionInfo:
     def __init__(self, preferred_version: str, versions: list[str]):
         self.preferred_version = preferred_version
         self.versions = versions
+
+
+# Discovery-time cache keyed by (group, version, plural) mapping each CRD to
+# its scope. Populated lazily via ``get_custom_resource_scope`` and reused
+# across per-namespace iterations of the custom-resource loop so we hit the
+# Kubernetes discovery endpoint at most once per CRD per cluster.
+CRD_SCOPE_CLUSTER = "Cluster"
+CRD_SCOPE_NAMESPACED = "Namespaced"
+
+
+def get_custom_resource_scope(api_client, group: str, version: str, plural: str,
+                              cache: dict) -> str:
+    """Return ``"Cluster"`` or ``"Namespaced"`` for the given CRD.
+
+    We hit the Kubernetes discovery endpoint ``/apis/{group}/{version}`` which
+    returns an ``APIResourceList`` with a ``namespaced`` boolean for every
+    resource in the group/version. Results are memoized in ``cache`` (a dict
+    scoped to a single cluster indexing pass) so a group with many resources
+    only costs one HTTP round trip.
+
+    Falls back to ``"Namespaced"`` on any error, which preserves the pre-fix
+    behavior for callers that hit permission problems while still allowing the
+    happy path to route cluster-scoped CRDs correctly.
+    """
+    cache_key = (group, version, plural)
+    if cache_key in cache:
+        return cache[cache_key]
+
+    resource_path = f"/apis/{group}/{version}" if group else f"/api/{version}"
+    try:
+        # ``call_api`` with response_type "object" returns the raw JSON as a
+        # dict, which is what we need to inspect the ``resources`` array.
+        response = api_client.call_api(
+            resource_path,
+            "GET",
+            response_type="object",
+            auth_settings=["BearerToken"],
+            _return_http_data_only=True,
+        )
+        resources = response.get("resources") if isinstance(response, dict) else None
+        if resources:
+            for resource_meta in resources:
+                if resource_meta.get("name") == plural:
+                    scope = (CRD_SCOPE_NAMESPACED
+                             if resource_meta.get("namespaced", True)
+                             else CRD_SCOPE_CLUSTER)
+                    cache[cache_key] = scope
+                    return scope
+        logger.info(f"Could not find scope metadata for custom resource "
+                    f"{plural}.{group}/{version}; defaulting to Namespaced")
+    except ApiException as e:
+        logger.info(f"Discovery call for {plural}.{group}/{version} failed "
+                    f"({e.status}); defaulting to Namespaced")
+    except Exception as e:  # noqa: BLE001 - defensive: never let scope lookup abort indexing
+        logger.info(f"Unexpected error resolving scope for "
+                    f"{plural}.{group}/{version}: {e}; defaulting to Namespaced")
+
+    cache[cache_key] = CRD_SCOPE_NAMESPACED
+    return CRD_SCOPE_NAMESPACED
 
 def get_lod_from_annotations(resource, lod_annotations: Dict[str, List[str]]) -> Optional[LevelOfDetail]:
     if not hasattr(resource, 'metadata'):
@@ -570,6 +629,15 @@ def index(component_context: Context):
                         # Connection validation successful, proceed with cluster indexing
                         core_api_client = client.CoreV1Api(api_client=api_client)
                         custom_objects_api_client = client.CustomObjectsApi(api_client=api_client)
+
+                        # Per-cluster caches for the custom-resource discovery loop.
+                        # ``crd_scope_cache`` memoizes scope lookups so we hit the
+                        # discovery endpoint at most once per CRD, and
+                        # ``cluster_scoped_crds_processed`` prevents cluster-scoped
+                        # CRDs from being listed once per namespace (they don't
+                        # belong to any namespace).
+                        crd_scope_cache: dict = {}
+                        cluster_scoped_crds_processed: set = set()
 
                         # Get the group info for all the available groups.
                         # This contains the preferred version and all available version, which
@@ -1143,10 +1211,31 @@ def index(component_context: Context):
                                         versions = list()
                                 try:
                                     for version in versions:
-                                        ret = custom_objects_api_client.list_namespaced_custom_object(group=group,
-                                                                                                      version=version,
-                                                                                                      namespace=namespace_name,
-                                                                                                      plural=plural_name)
+                                        # Determine CRD scope once per (group, version, plural).
+                                        # This lets us dispatch to the correct API and avoid
+                                        # re-listing cluster-scoped CRDs for every namespace.
+                                        scope = get_custom_resource_scope(api_client,
+                                                                          group,
+                                                                          version,
+                                                                          plural_name,
+                                                                          crd_scope_cache)
+
+                                        if scope == CRD_SCOPE_CLUSTER:
+                                            processed_key = (cluster_name, group, version, plural_name)
+                                            if processed_key in cluster_scoped_crds_processed:
+                                                # Already indexed for this cluster in a prior
+                                                # namespace iteration; nothing more to do.
+                                                continue
+                                            cluster_scoped_crds_processed.add(processed_key)
+                                            ret = custom_objects_api_client.list_cluster_custom_object(group=group,
+                                                                                                       version=version,
+                                                                                                       plural=plural_name)
+                                        else:
+                                            ret = custom_objects_api_client.list_namespaced_custom_object(group=group,
+                                                                                                          version=version,
+                                                                                                          namespace=namespace_name,
+                                                                                                          plural=plural_name)
+
                                         for raw_resource in ret['items']:
                                             if (include_annotations or include_labels) and not has_included_annotations_or_labels(raw_resource, include_annotations, include_labels):
                                                 continue  # Skip this resource if it doesn't meet inclusion criteria
@@ -1156,12 +1245,18 @@ def index(component_context: Context):
                                             owner_name = extract_owner_name(raw_resource)
                                             resource_name = raw_resource['metadata']['name']
                                             custom_name = f"{plural_name}_{group}_{version}_{resource_name}"
-                                            custom_qualified_name = get_qualified_name(namespace_qualified_name, custom_name)
                                             custom_attributes = kubeapi_parsers.parse_custom_resource(raw_resource,
                                                                                                       group,
                                                                                                       version,
                                                                                                       plural_name)
-                                            custom_attributes["namespace"] = namespace
+                                            if scope == CRD_SCOPE_CLUSTER:
+                                                # Cluster-scoped resources are parented directly
+                                                # to the cluster; they have no owning namespace.
+                                                custom_qualified_name = get_qualified_name(cluster_name, custom_name)
+                                                custom_attributes["cluster"] = cluster
+                                            else:
+                                                custom_qualified_name = get_qualified_name(namespace_qualified_name, custom_name)
+                                                custom_attributes["namespace"] = namespace
                                             if owner_name:
                                                 custom_attributes['owner'] = owner_name
                                             custom_resource = registry.add_resource(KUBERNETES_PLATFORM,

--- a/src/indexers/kubeapi.py
+++ b/src/indexers/kubeapi.py
@@ -147,6 +147,48 @@ def get_custom_resource_scope(api_client, group: str, version: str, plural: str,
     cache[cache_key] = CRD_SCOPE_NAMESPACED
     return CRD_SCOPE_NAMESPACED
 
+
+def list_custom_resource_for_scope(custom_objects_api_client,
+                                   scope: str,
+                                   group: str,
+                                   version: str,
+                                   plural: str,
+                                   namespace_name: Optional[str],
+                                   processed_key: tuple,
+                                   cluster_scoped_crds_processed: set):
+    """Dispatch a CRD listing call according to scope, honoring a
+    per-cluster "already processed" set for cluster-scoped resources.
+
+    Returns the raw list response, or ``None`` if this cluster-scoped
+    CRD has already been indexed for the current cluster and the caller
+    should short-circuit to the next iteration.
+
+    The processed marker is added ONLY AFTER
+    ``list_cluster_custom_object`` returns successfully. Marking before
+    the call would let a transient ``ApiException`` on the first
+    namespace iteration silently drop the CRD for the rest of the
+    cluster scan; leaving the marker unset lets subsequent namespace
+    iterations retry. Persistent failures (e.g. missing RBAC) will
+    re-log per namespace iteration, which is noisy but correct.
+    """
+    if scope == CRD_SCOPE_CLUSTER:
+        if processed_key in cluster_scoped_crds_processed:
+            return None
+        ret = custom_objects_api_client.list_cluster_custom_object(
+            group=group,
+            version=version,
+            plural=plural,
+        )
+        cluster_scoped_crds_processed.add(processed_key)
+        return ret
+    return custom_objects_api_client.list_namespaced_custom_object(
+        group=group,
+        version=version,
+        namespace=namespace_name,
+        plural=plural,
+    )
+
+
 def get_lod_from_annotations(resource, lod_annotations: Dict[str, List[str]]) -> Optional[LevelOfDetail]:
     if not hasattr(resource, 'metadata'):
         return None
@@ -1220,21 +1262,21 @@ def index(component_context: Context):
                                                                           plural_name,
                                                                           crd_scope_cache)
 
-                                        if scope == CRD_SCOPE_CLUSTER:
-                                            processed_key = (cluster_name, group, version, plural_name)
-                                            if processed_key in cluster_scoped_crds_processed:
-                                                # Already indexed for this cluster in a prior
-                                                # namespace iteration; nothing more to do.
-                                                continue
-                                            cluster_scoped_crds_processed.add(processed_key)
-                                            ret = custom_objects_api_client.list_cluster_custom_object(group=group,
-                                                                                                       version=version,
-                                                                                                       plural=plural_name)
-                                        else:
-                                            ret = custom_objects_api_client.list_namespaced_custom_object(group=group,
-                                                                                                          version=version,
-                                                                                                          namespace=namespace_name,
-                                                                                                          plural=plural_name)
+                                        processed_key = (cluster_name, group, version, plural_name)
+                                        ret = list_custom_resource_for_scope(
+                                            custom_objects_api_client,
+                                            scope,
+                                            group,
+                                            version,
+                                            plural_name,
+                                            namespace_name,
+                                            processed_key,
+                                            cluster_scoped_crds_processed,
+                                        )
+                                        if ret is None:
+                                            # Cluster-scoped CRD already indexed for this
+                                            # cluster in a prior namespace iteration.
+                                            continue
 
                                         for raw_resource in ret['items']:
                                             if (include_annotations or include_labels) and not has_included_annotations_or_labels(raw_resource, include_annotations, include_labels):

--- a/src/indexers/kubeapi.py
+++ b/src/indexers/kubeapi.py
@@ -1278,6 +1278,15 @@ def index(component_context: Context):
                                             # cluster in a prior namespace iteration.
                                             continue
 
+                                        # Every CRD gets its own resource_type bucket in the
+                                        # registry keyed by "{plural}.{group}" (e.g.
+                                        # "buckets.storage.gcp.upbound.io"). This replaces the
+                                        # earlier lump-everything-into-"custom" model, which
+                                        # forced a linear search-and-filter pass at enrichment
+                                        # time and produced opaque qualified names like
+                                        # ``ns/plural_group_version_name``.
+                                        crd_type_name = f"{plural_name}.{group}"
+
                                         for raw_resource in ret['items']:
                                             if (include_annotations or include_labels) and not has_included_annotations_or_labels(raw_resource, include_annotations, include_labels):
                                                 continue  # Skip this resource if it doesn't meet inclusion criteria
@@ -1286,7 +1295,6 @@ def index(component_context: Context):
                                                 continue
                                             owner_name = extract_owner_name(raw_resource)
                                             resource_name = raw_resource['metadata']['name']
-                                            custom_name = f"{plural_name}_{group}_{version}_{resource_name}"
                                             custom_attributes = kubeapi_parsers.parse_custom_resource(raw_resource,
                                                                                                       group,
                                                                                                       version,
@@ -1294,15 +1302,22 @@ def index(component_context: Context):
                                             if scope == CRD_SCOPE_CLUSTER:
                                                 # Cluster-scoped resources are parented directly
                                                 # to the cluster; they have no owning namespace.
-                                                custom_qualified_name = get_qualified_name(cluster_name, custom_name)
+                                                # Qualified name shape:
+                                                #   <cluster>/<plural>.<group>/<name>
+                                                crd_type_qualified_name = get_qualified_name(cluster_name, crd_type_name)
+                                                custom_qualified_name = get_qualified_name(crd_type_qualified_name, resource_name)
                                                 custom_attributes["cluster"] = cluster
                                             else:
-                                                custom_qualified_name = get_qualified_name(namespace_qualified_name, custom_name)
+                                                # Namespaced resources are parented under the
+                                                # namespace. Qualified name shape:
+                                                #   <cluster>/<namespace>/<plural>.<group>/<name>
+                                                crd_type_qualified_name = get_qualified_name(namespace_qualified_name, crd_type_name)
+                                                custom_qualified_name = get_qualified_name(crd_type_qualified_name, resource_name)
                                                 custom_attributes["namespace"] = namespace
                                             if owner_name:
                                                 custom_attributes['owner'] = owner_name
                                             custom_resource = registry.add_resource(KUBERNETES_PLATFORM,
-                                                                                    KubernetesResourceType.CUSTOM.value,
+                                                                                    crd_type_name,
                                                                                     resource_name,
                                                                                     custom_qualified_name,
                                                                                     custom_attributes)

--- a/src/indexers/kubetypes.py
+++ b/src/indexers/kubetypes.py
@@ -142,15 +142,21 @@ def get_namespace(resource: Resource) -> Optional[Resource]:
         # TODO: Should possibly raise an exception here instead?
         return None
     else:
-        return getattr(resource, "namespace")
+        # Cluster-scoped custom resources (e.g. Crossplane managed resources)
+        # have no owning namespace, so ``getattr`` must tolerate an absent
+        # ``namespace`` attribute.
+        return getattr(resource, "namespace", None)
 
 def get_cluster(resource: Resource) -> Optional[Resource]:
     check_kubernetes_resource(resource)
     if resource.resource_type.name == KubernetesResourceType.CLUSTER.value:
         return resource
-    else:
-        namespace = get_namespace(resource)
-        return getattr(namespace, "cluster")
+    namespace = get_namespace(resource)
+    if namespace is not None:
+        return getattr(namespace, "cluster", None)
+    # Cluster-scoped custom resources carry the cluster reference directly on
+    # the resource itself (see the indexer's custom-resource loop).
+    return getattr(resource, "cluster", None)
 
 def get_context(resource: Resource) -> Optional[str]:
     check_kubernetes_resource(resource)

--- a/src/indexers/test_kubeapi_crd_scope.py
+++ b/src/indexers/test_kubeapi_crd_scope.py
@@ -1,0 +1,217 @@
+"""Unit tests for the CRD scope-detection helper added to
+``indexers.kubeapi`` so that the workspace-builder can distinguish
+namespaced from cluster-scoped custom resources at index time and
+dispatch to the correct Kubernetes API.
+
+Prior to this fix, the custom-resource loop unconditionally called
+``list_namespaced_custom_object`` for every discovered CRD from inside a
+per-namespace loop. That works for the CRDs any existing generation rule
+in ``rw-cli-codecollection`` targets (all namespaced), but returns
+``404 Not Found`` for cluster-scoped CRDs like Crossplane managed
+resources (``buckets.storage.gcp.upbound.io``, ``hmackeys...``, etc.).
+
+These tests pin the scope-detection behavior in isolation:
+
+* it queries the correct discovery path,
+* it correctly reads the ``namespaced`` boolean from the returned
+  ``APIResourceList``,
+* it memoizes results in a per-cluster cache so a group with many
+  resources only costs one HTTP call,
+* it falls back to ``Namespaced`` on any error (preserving the pre-fix
+  behavior for callers hitting permission problems),
+* and it caches the fallback so we do not retry every namespace.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from unittest import TestCase
+from unittest.mock import MagicMock
+
+_THIS_DIR = os.path.dirname(os.path.abspath(__file__))
+_SRC_DIR = os.path.dirname(_THIS_DIR)
+if _SRC_DIR not in sys.path:
+    sys.path.insert(0, _SRC_DIR)
+
+from kubernetes.client.rest import ApiException  # noqa: E402
+
+from indexers.kubeapi import (  # noqa: E402
+    CRD_SCOPE_CLUSTER,
+    CRD_SCOPE_NAMESPACED,
+    get_custom_resource_scope,
+)
+
+
+def _api_resource_list(resources):
+    """Wrap a list of resource dicts in the shape returned by
+    ``/apis/{group}/{version}`` (an ``APIResourceList``)."""
+    return {
+        "kind": "APIResourceList",
+        "apiVersion": "v1",
+        "resources": resources,
+    }
+
+
+def _make_api_client(response):
+    """Build a mock api_client whose ``call_api`` returns ``response``.
+    The real Kubernetes client's ``call_api`` returns raw JSON when
+    ``response_type='object'`` and ``_return_http_data_only=True`` are
+    passed, so that's what we mimic here."""
+    api_client = MagicMock()
+    api_client.call_api = MagicMock(return_value=response)
+    return api_client
+
+
+class GetCustomResourceScopeTest(TestCase):
+    def test_cluster_scoped_resource(self):
+        """A CRD with ``namespaced: false`` resolves to ``Cluster``."""
+        response = _api_resource_list([
+            {"name": "buckets", "namespaced": False, "kind": "Bucket"},
+            {"name": "buckets/status", "namespaced": False, "kind": "Bucket"},
+        ])
+        api_client = _make_api_client(response)
+        cache = {}
+        scope = get_custom_resource_scope(
+            api_client, "storage.gcp.upbound.io", "v1beta2", "buckets", cache,
+        )
+        self.assertEqual(scope, CRD_SCOPE_CLUSTER)
+        self.assertEqual(cache[("storage.gcp.upbound.io", "v1beta2", "buckets")], CRD_SCOPE_CLUSTER)
+
+    def test_namespaced_resource(self):
+        """A CRD with ``namespaced: true`` resolves to ``Namespaced``."""
+        response = _api_resource_list([
+            {"name": "helmreleases", "namespaced": True, "kind": "HelmRelease"},
+        ])
+        api_client = _make_api_client(response)
+        cache = {}
+        scope = get_custom_resource_scope(
+            api_client, "helm.toolkit.fluxcd.io", "v2beta1", "helmreleases", cache,
+        )
+        self.assertEqual(scope, CRD_SCOPE_NAMESPACED)
+
+    def test_calls_discovery_endpoint_for_group_version(self):
+        """The helper must hit ``/apis/{group}/{version}``."""
+        api_client = _make_api_client(_api_resource_list([
+            {"name": "buckets", "namespaced": False, "kind": "Bucket"},
+        ]))
+        get_custom_resource_scope(
+            api_client, "storage.gcp.upbound.io", "v1beta2", "buckets", {},
+        )
+        args, _ = api_client.call_api.call_args
+        # First positional arg is the path; second is the HTTP method.
+        self.assertEqual(args[0], "/apis/storage.gcp.upbound.io/v1beta2")
+        self.assertEqual(args[1], "GET")
+
+    def test_caches_result_across_calls(self):
+        """A cache hit must short-circuit the discovery call."""
+        response = _api_resource_list([
+            {"name": "buckets", "namespaced": False, "kind": "Bucket"},
+        ])
+        api_client = _make_api_client(response)
+        cache = {}
+        # First call populates the cache.
+        get_custom_resource_scope(
+            api_client, "storage.gcp.upbound.io", "v1beta2", "buckets", cache,
+        )
+        # Second call for the same key must NOT re-hit the API.
+        api_client.call_api.reset_mock()
+        scope = get_custom_resource_scope(
+            api_client, "storage.gcp.upbound.io", "v1beta2", "buckets", cache,
+        )
+        self.assertEqual(scope, CRD_SCOPE_CLUSTER)
+        api_client.call_api.assert_not_called()
+
+    def test_multiple_resources_in_group_share_one_api_call(self):
+        """Two CRDs in the same group/version only cost one discovery call
+        because the cache is keyed by (group, version, plural) and the
+        response already carries every resource in the group."""
+        response = _api_resource_list([
+            {"name": "buckets", "namespaced": False, "kind": "Bucket"},
+            {"name": "hmackeys", "namespaced": False, "kind": "HMACKey"},
+        ])
+        api_client = _make_api_client(response)
+        cache = {}
+        s1 = get_custom_resource_scope(
+            api_client, "storage.gcp.upbound.io", "v1beta2", "buckets", cache,
+        )
+        s2 = get_custom_resource_scope(
+            api_client, "storage.gcp.upbound.io", "v1beta2", "hmackeys", cache,
+        )
+        # Both are cluster-scoped.
+        self.assertEqual(s1, CRD_SCOPE_CLUSTER)
+        self.assertEqual(s2, CRD_SCOPE_CLUSTER)
+        # Two API calls today (one per plural). Cheap enough — one round trip
+        # per (group, plural) — and keeps the cache key precise. If we ever
+        # want to cache per (group, version) we can revisit.
+        self.assertEqual(api_client.call_api.call_count, 2)
+
+    def test_api_exception_falls_back_to_namespaced(self):
+        """A permissions failure or transient error must not abort discovery."""
+        api_client = MagicMock()
+        api_client.call_api = MagicMock(
+            side_effect=ApiException(status=403, reason="Forbidden"),
+        )
+        cache = {}
+        scope = get_custom_resource_scope(
+            api_client, "storage.gcp.upbound.io", "v1beta2", "buckets", cache,
+        )
+        self.assertEqual(scope, CRD_SCOPE_NAMESPACED)
+        # Fallback is cached so we do not retry per-namespace.
+        self.assertEqual(cache[("storage.gcp.upbound.io", "v1beta2", "buckets")], CRD_SCOPE_NAMESPACED)
+
+    def test_unexpected_exception_falls_back_to_namespaced(self):
+        """Any non-Kubernetes exception is also caught defensively."""
+        api_client = MagicMock()
+        api_client.call_api = MagicMock(side_effect=RuntimeError("boom"))
+        scope = get_custom_resource_scope(
+            api_client, "storage.gcp.upbound.io", "v1beta2", "buckets", {},
+        )
+        self.assertEqual(scope, CRD_SCOPE_NAMESPACED)
+
+    def test_missing_plural_in_response_falls_back_to_namespaced(self):
+        """If the API returns a valid response that doesn't list our plural
+        (schema drift, subresource-only, etc.) we default to Namespaced and
+        cache that so we don't repeat the discovery call for every namespace."""
+        response = _api_resource_list([
+            {"name": "somethingelse", "namespaced": True, "kind": "SomethingElse"},
+        ])
+        api_client = _make_api_client(response)
+        cache = {}
+        scope = get_custom_resource_scope(
+            api_client, "storage.gcp.upbound.io", "v1beta2", "buckets", cache,
+        )
+        self.assertEqual(scope, CRD_SCOPE_NAMESPACED)
+        self.assertEqual(cache[("storage.gcp.upbound.io", "v1beta2", "buckets")], CRD_SCOPE_NAMESPACED)
+
+    def test_missing_namespaced_field_defaults_to_namespaced(self):
+        """If the ``namespaced`` field is absent from the resource entry we
+        conservatively treat it as Namespaced, matching the pre-fix path."""
+        response = _api_resource_list([
+            {"name": "buckets", "kind": "Bucket"},  # no `namespaced` key
+        ])
+        api_client = _make_api_client(response)
+        scope = get_custom_resource_scope(
+            api_client, "storage.gcp.upbound.io", "v1beta2", "buckets", {},
+        )
+        self.assertEqual(scope, CRD_SCOPE_NAMESPACED)
+
+    def test_core_group_uses_legacy_api_path(self):
+        """Resources in the core (empty-group) API live under ``/api/{version}``
+        instead of ``/apis/{group}/{version}``. Nobody targets core resources
+        via the custom-resource loop today, but the helper handles the shape
+        correctly so a future caller can't fall into a subtle path bug."""
+        response = _api_resource_list([
+            {"name": "namespaces", "namespaced": False, "kind": "Namespace"},
+        ])
+        api_client = _make_api_client(response)
+        get_custom_resource_scope(
+            api_client, "", "v1", "namespaces", {},
+        )
+        args, _ = api_client.call_api.call_args
+        self.assertEqual(args[0], "/api/v1")
+
+
+if __name__ == "__main__":
+    import unittest
+    unittest.main()

--- a/src/indexers/test_kubeapi_crd_scope.py
+++ b/src/indexers/test_kubeapi_crd_scope.py
@@ -40,6 +40,7 @@ from indexers.kubeapi import (  # noqa: E402
     CRD_SCOPE_CLUSTER,
     CRD_SCOPE_NAMESPACED,
     get_custom_resource_scope,
+    list_custom_resource_for_scope,
 )
 
 
@@ -210,6 +211,168 @@ class GetCustomResourceScopeTest(TestCase):
         )
         args, _ = api_client.call_api.call_args
         self.assertEqual(args[0], "/api/v1")
+
+
+class ListCustomResourceForScopeTest(TestCase):
+    """Regression tests for the marker semantics in
+    ``list_custom_resource_for_scope``.
+
+    Pins the invariant that a cluster-scoped CRD is marked as
+    "processed for this cluster" ONLY AFTER
+    ``list_cluster_custom_object`` returns successfully. Marking before
+    the call would allow a transient ``ApiException`` on the first
+    namespace iteration to silently drop the CRD for every subsequent
+    iteration (see the review comment on
+    https://github.com/runwhen-contrib/runwhen-local/pull/806).
+    """
+
+    def _mock_custom_objects_api(self):
+        client = MagicMock()
+        client.list_cluster_custom_object = MagicMock()
+        client.list_namespaced_custom_object = MagicMock()
+        return client
+
+    def test_namespaced_dispatches_to_namespaced_call(self):
+        client = self._mock_custom_objects_api()
+        client.list_namespaced_custom_object.return_value = {"items": []}
+        processed = set()
+
+        result = list_custom_resource_for_scope(
+            client,
+            CRD_SCOPE_NAMESPACED,
+            "helm.toolkit.fluxcd.io",
+            "v2beta1",
+            "helmreleases",
+            "kube-system",
+            ("clus", "helm.toolkit.fluxcd.io", "v2beta1", "helmreleases"),
+            processed,
+        )
+
+        client.list_namespaced_custom_object.assert_called_once_with(
+            group="helm.toolkit.fluxcd.io",
+            version="v2beta1",
+            namespace="kube-system",
+            plural="helmreleases",
+        )
+        client.list_cluster_custom_object.assert_not_called()
+        # Namespaced flow does not touch the processed set.
+        self.assertEqual(processed, set())
+        self.assertEqual(result, {"items": []})
+
+    def test_cluster_scoped_first_call_lists_and_marks_processed(self):
+        client = self._mock_custom_objects_api()
+        client.list_cluster_custom_object.return_value = {"items": [{"metadata": {"name": "b1"}}]}
+        processed = set()
+        key = ("clus", "storage.gcp.upbound.io", "v1beta2", "buckets")
+
+        result = list_custom_resource_for_scope(
+            client,
+            CRD_SCOPE_CLUSTER,
+            "storage.gcp.upbound.io",
+            "v1beta2",
+            "buckets",
+            "kube-system",  # namespace arg is ignored for cluster-scoped
+            key,
+            processed,
+        )
+
+        client.list_cluster_custom_object.assert_called_once_with(
+            group="storage.gcp.upbound.io",
+            version="v1beta2",
+            plural="buckets",
+        )
+        client.list_namespaced_custom_object.assert_not_called()
+        # Marker MUST be added only after the successful call.
+        self.assertIn(key, processed)
+        self.assertEqual(result["items"][0]["metadata"]["name"], "b1")
+
+    def test_cluster_scoped_second_call_short_circuits(self):
+        """Once marked, subsequent namespace iterations skip the API."""
+        client = self._mock_custom_objects_api()
+        processed = {("clus", "storage.gcp.upbound.io", "v1beta2", "buckets")}
+
+        result = list_custom_resource_for_scope(
+            client,
+            CRD_SCOPE_CLUSTER,
+            "storage.gcp.upbound.io",
+            "v1beta2",
+            "buckets",
+            "kube-public",
+            ("clus", "storage.gcp.upbound.io", "v1beta2", "buckets"),
+            processed,
+        )
+
+        self.assertIsNone(result)
+        client.list_cluster_custom_object.assert_not_called()
+        client.list_namespaced_custom_object.assert_not_called()
+
+    def test_cluster_scoped_transient_failure_does_not_mark_processed(self):
+        """The core Bugbot regression: a first-pass ``ApiException`` must
+        NOT lock the CRD out of subsequent retries."""
+        client = self._mock_custom_objects_api()
+        client.list_cluster_custom_object.side_effect = ApiException(
+            status=503, reason="Service Unavailable",
+        )
+        processed = set()
+        key = ("clus", "storage.gcp.upbound.io", "v1beta2", "buckets")
+
+        with self.assertRaises(ApiException):
+            list_custom_resource_for_scope(
+                client,
+                CRD_SCOPE_CLUSTER,
+                "storage.gcp.upbound.io",
+                "v1beta2",
+                "buckets",
+                "kube-system",
+                key,
+                processed,
+            )
+
+        # Marker must be absent so the outer loop's next namespace iteration
+        # retries.
+        self.assertNotIn(key, processed)
+
+    def test_cluster_scoped_retry_after_failure_succeeds_and_marks_processed(self):
+        """End-to-end scenario over two namespace iterations: first pass
+        raises, second pass succeeds and marks the CRD processed. A
+        hypothetical third iteration is short-circuited."""
+        client = self._mock_custom_objects_api()
+        successful_body = {"items": [{"metadata": {"name": "b1"}}]}
+        client.list_cluster_custom_object.side_effect = [
+            ApiException(status=503, reason="Service Unavailable"),
+            successful_body,
+        ]
+        processed = set()
+        key = ("clus", "storage.gcp.upbound.io", "v1beta2", "buckets")
+
+        # First namespace iteration: transient failure, no marker.
+        with self.assertRaises(ApiException):
+            list_custom_resource_for_scope(
+                client, CRD_SCOPE_CLUSTER,
+                "storage.gcp.upbound.io", "v1beta2", "buckets",
+                "kube-system", key, processed,
+            )
+        self.assertNotIn(key, processed)
+
+        # Second namespace iteration: succeeds, marker recorded.
+        result = list_custom_resource_for_scope(
+            client, CRD_SCOPE_CLUSTER,
+            "storage.gcp.upbound.io", "v1beta2", "buckets",
+            "kube-public", key, processed,
+        )
+        self.assertEqual(result, successful_body)
+        self.assertIn(key, processed)
+
+        # Third namespace iteration: short-circuit.
+        result = list_custom_resource_for_scope(
+            client, CRD_SCOPE_CLUSTER,
+            "storage.gcp.upbound.io", "v1beta2", "buckets",
+            "default", key, processed,
+        )
+        self.assertIsNone(result)
+
+        # API was invoked exactly twice (attempt + retry). Not thrice.
+        self.assertEqual(client.list_cluster_custom_object.call_count, 2)
 
 
 if __name__ == "__main__":

--- a/src/templates/kubernetes-tags.yaml
+++ b/src/templates/kubernetes-tags.yaml
@@ -45,10 +45,11 @@
       value: '{{ _cr_value }}'
 {% endif %}
 {% endfor %}
-{% if match_resource.resource_type.name == "custom" and match_resource.kind is defined %}
-    - name: resource_type
-      value: '{{ match_resource.kind | lower | string }}'
-{% elif match_resource.resource_type %}
+{# Custom resources are stored in the registry under their "{plural}.{group}"
+   type name (e.g. "buckets.storage.gcp.upbound.io"); built-in Kubernetes
+   resources use the singular kind ("deployment", "service", ...). Both are
+   surfaced verbatim as the resource_type tag. #}
+{% if match_resource.resource_type %}
     - name: resource_type
       value: '{{ match_resource.resource_type.name | string }}'
 {% endif %}


### PR DESCRIPTION
## Summary

Fixes two narrow, conditional bugs in the workspace-builder's custom-resource loop that block generation rules targeting CRDs whose *shape* falls outside anything currently referenced by `rw-cli-codecollection`, and — as a follow-up commit on this branch — makes custom resources first-class in the registry with readable qualified names. Existing generation rules keep working; every CRD used today is namespaced and unversioned, so neither bug ever fired in tree. Both were surfaced building a `generation-rule-only` codebundle for Crossplane managed resources.

### Fix #1 — `KubernetesResourceTypeSpec` `NameError` when a rule pins a version

`src/indexers/kubeapi.py` references `KubernetesResourceTypeSpec` inside `if version:` at ~L1183 to build a wildcard-de-dup key, but the module only imported `KubernetesResourceType`. Any rule specifying a CRD as `plural.group/vX` (e.g. `buckets.storage.gcp.upbound.io/v1beta1`) hits a fatal `NameError` that aborts the whole cluster's CRD enumeration. One-line import fix.

### Fix #2 — Cluster-scoped CRDs 404 on the namespaced listing call

The custom-resource loop lived inside `for namespace_name in namespace_names:` and unconditionally called `list_namespaced_custom_object`. For cluster-scoped CRDs there's no `/apis/{group}/{version}/namespaces/{ns}/{plural}` collection, so the API server returns 404 for every namespace iteration and no resources are indexed. This is the first cluster-scoped CRD the pattern has been used against — every existing generation rule target (`applications.argoproj.io`, `helmreleases.helm.toolkit.fluxcd.io`, `certificates.cert-manager.io`, `prometheuses.monitoring.coreos.com`, `postgresclusters...`, `postgresqls...`, etc.) is namespaced.

- New helper `get_custom_resource_scope(api_client, group, version, plural, cache)` calls the discovery endpoint `/apis/{group}/{version}` and reads the per-resource `namespaced` boolean. Results are memoized in a per-cluster cache so a group with many CRDs costs one round trip.
- On any error (permissions, transient, schema drift) the helper falls back to `Namespaced` and caches that, preserving the pre-fix behavior for callers who hit permission issues.
- Cluster-scoped CRDs are indexed **once per cluster** (guarded by `cluster_scoped_crds_processed`) via `list_custom_resource_for_scope`, which marks the CRD as processed **only after `list_cluster_custom_object` returns successfully** so a transient `ApiException` on the first namespace pass doesn't lock the CRD out of subsequent retries (addressed a Bugbot review comment).
- Namespaced CRDs keep the existing per-namespace flow byte-for-byte.

Downstream helpers (`kubetypes.get_namespace/get_cluster`, `enrichers.kubernetes.get_common_resource_property_values`) were updated to gracefully return `None` for cluster-scoped resources with no owning namespace instead of raising `AttributeError`.

### Follow-up (third commit): first-class CRD resource types + readable qualified names

Prior to this commit, every custom resource landed under a single `resource_type: "custom"` bucket with a mangled qualified name like `default/buckets_storage.gcp.upbound.io_v1beta2_my-bucket` — opaque in the resource store, opaque in MCP query output, and requiring a linear-search-and-filter pass at enrichment time to disambiguate kinds.

The indexer now registers each CRD under its own registry bucket keyed by `{plural}.{group}` (e.g. `buckets.storage.gcp.upbound.io`), and the qualified names become path-shaped:

| Old | New |
|-----|-----|
| `default/buckets_storage.gcp.upbound.io_v1beta2_my-bucket` (cluster-scoped) | `default/buckets.storage.gcp.upbound.io/my-bucket` |
| `default/kube-system/helmreleases_helm.toolkit.fluxcd.io_v2beta1_myapp` (namespaced) | `default/kube-system/helmreleases.helm.toolkit.fluxcd.io/myapp` |
| `resource_type: custom` | `resource_type: buckets.storage.gcp.upbound.io` |

The enricher's `get_resources` short-circuits directly to the CRD's own bucket for a CUSTOM spec (looking up `{spec.kind}.{spec.group}`) instead of iterating every discovered custom resource and filtering by plural/group. Version pinning still works. `kubernetes-tags.yaml` no longer special-cases `"custom"` — `resource_type.name` is already the proper `plural.group` string.

**Compatibility note**: The qualified_name format for any CRD instance changes. This is not a persisted-schema concern because workspace-builder recomputes the registry from scratch on every run, but any tooling that scraped the old `plural_group_version_name` shape will need to migrate. Nothing in-tree does that.

## Files changed

| File | Purpose |
|------|---------|
| `src/indexers/kubeapi.py` | Import fix, scope-aware dispatch, per-cluster caches, marker-after-success, per-CRD registry buckets, readable qualified names |
| `src/indexers/kubetypes.py` | `get_namespace`/`get_cluster` tolerate missing `namespace` for cluster-scoped custom resources |
| `src/enrichers/kubernetes.py` | `namespace`/`cluster` qualifier lookups return `None` instead of raising; `get_resources` looks up specific CRD types |
| `src/templates/kubernetes-tags.yaml` | Drop the legacy `"custom"` special case (resource_type.name is already the proper `plural.group`) |
| `src/indexers/test_kubeapi_crd_scope.py` | 15 unit tests for the scope helper + marker semantics |
| `src/enrichers/test_kubernetes_crd_lookup.py` | 8 unit tests for the enricher's per-CRD lookup |

## Test plan

- [x] `poetry run python -m unittest indexers.test_kubeapi_crd_scope enrichers.test_kubernetes_crd_lookup -v` — 23/23 passing
- [x] Full `src/` discovery: **365 passed, 0 failed** (was 352 before this branch — +13 new tests)
- [x] End-to-end validation against the airgap cluster with image `806-merge-343c86e3` (first two commits): 8 real Crossplane `buckets.storage.gcp.upbound.io` instances discovered and rendered as SLXs. The follow-up commit reshapes those registry entries; will re-validate against a fresh merge-preview image tag.

## Background

Discovered while building an educational `generation-rule-only` codebundle for Crossplane GCP `Bucket` resources (a private CC that ships only rules + templates and delegates runtime to `rw-generic-codecollection/k8s-kubectl-cmd`). The pattern works — the workspace-builder clones the CC, parses the rule, and attempts discovery — but every attempted list returned 404 because Crossplane managed resources are cluster-scoped.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Kubernetes custom-resource discovery, registry identity, and qualified names (breaking for out-of-tree consumers of the old CRD name shape), but namespaced CRDs keep the same list path and errors fall back to the prior namespaced behavior.
> 
> **Overview**
> **Custom resource indexing** now discovers whether each CRD is cluster- or namespaced-scoped (via the Kubernetes discovery API, cached per cluster), lists cluster-scoped types once with `list_cluster_custom_object` instead of failing with 404 on repeated namespaced calls, and only marks a cluster-scoped CRD as “processed” after a successful list so transient errors can retry on later namespace iterations.
> 
> **Registry model** replaces the single `"custom"` bucket with per-CRD buckets keyed by `{plural}.{group}`, path-shaped qualified names, and direct enricher lookup by `{kind}.{group}` (version pinning unchanged). Cluster-scoped instances parent to the cluster with no namespace; `get_namespace` / `get_cluster` and tag qualifiers return `None` safely instead of raising.
> 
> **Tags**: `kubernetes-tags.yaml` drops the legacy `"custom"` `resource_type` special case—`resource_type.name` is already `{plural}.{group}`.
> 
> Also adds the missing `KubernetesResourceTypeSpec` import for version-pinned generation rules, bumps version to **0.11.2**, and adds unit tests for scope dispatch and CRD lookup. **Note:** CRD `qualified_name` shape changes on every workspace build (not persisted), which may affect external tooling that assumed the old `plural_group_version_name` form.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 40e364489d84e0916d3265ddb2f4f7ab2e4993ed. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->