### PR TITLE
chore: bump version to 0.11.4 and update GKE auth templates

### DIFF
--- a/docs/authoring/generation-rules/README.md
+++ b/docs/authoring/generation-rules/README.md
@@ -150,7 +150,5 @@ advanced cases.
 
 * [`generation-rules-guide.md`](../../../generation-rules-guide.md) — full
   syntax reference
-* [Worked examples](./examples/) — end-to-end narratives
 * [Tag-hierarchy contract](./tag-hierarchy-contract.md)
 * [Indexed resources](../indexed-resources/README.md) — matchable type catalogs
-* [Concepts](../concepts.md) — CodeCollection / Skill / SLX terminology

--- a/docs/authoring/indexed-resources/README.md
+++ b/docs/authoring/indexed-resources/README.md
@@ -1,15 +1,20 @@
 # Indexed resource catalogs
 
-Agent- and author-facing lookup tables for generation-rule `resourceTypes` and
-`match_resource.*` properties.
+When you write a generation rule, `resourceTypes` and `matchRules` need the
+exact resource-type names and match properties an indexer produces. These
+pages are the lookup tables.
 
-| Platform | Narrative guide | Machine catalog |
+Each platform has a **narrative guide** (the common types and match properties,
+with a worked example) here, plus a full **machine catalog** of every
+discoverable type on GitHub.
+
+| Platform | Narrative guide | Full catalog (GitHub) |
 |---|---|---|
-| Kubernetes | [kubernetes.md](./kubernetes.md) | [kubernetes-resource-catalog.md](./kubernetes-resource-catalog.md) |
-| Azure | [azure.md](./azure.md) | [azure-resource-catalog.md](./azure-resource-catalog.md) |
-| GCP | [gcp.md](./gcp.md) | [gcp-resource-catalog.md](./gcp-resource-catalog.md) |
-| AWS | [aws.md](./aws.md) | [aws-resource-catalog.md](./aws-resource-catalog.md) |
-| RunWhen | [runwhen-platform.md](./runwhen-platform.md) | [runwhen-platform-resource-catalog.md](./runwhen-platform-resource-catalog.md) |
+| Kubernetes | [kubernetes.md](./kubernetes.md) | [kubernetes-resource-catalog.md](https://github.com/runwhen-contrib/runwhen-local/blob/main/docs/authoring/indexed-resources/kubernetes-resource-catalog.md) |
+| Azure | [azure.md](./azure.md) | [azure-resource-catalog.md](https://github.com/runwhen-contrib/runwhen-local/blob/main/docs/authoring/indexed-resources/azure-resource-catalog.md) |
+| GCP | [gcp.md](./gcp.md) | [gcp-resource-catalog.md](https://github.com/runwhen-contrib/runwhen-local/blob/main/docs/authoring/indexed-resources/gcp-resource-catalog.md) |
+| AWS | [aws.md](./aws.md) | [aws-resource-catalog.md](https://github.com/runwhen-contrib/runwhen-local/blob/main/docs/authoring/indexed-resources/aws-resource-catalog.md) |
+| RunWhen | [runwhen-platform.md](./runwhen-platform.md) | [runwhen-platform-resource-catalog.md](https://github.com/runwhen-contrib/runwhen-local/blob/main/docs/authoring/indexed-resources/runwhen-platform-resource-catalog.md) |
 
-Regenerate catalogs with the dump scripts under `scripts/` or via the
-`publish-discovery-catalog` GitHub Action.
+New to generation rules? Start with the
+[Generation Rules schema](../generation-rules/README.md).

--- a/src/VERSION
+++ b/src/VERSION
@@ -1,4 +1,4 @@
 {
   "name": "runwhen-local",
-  "version": "0.11.3"
+  "version": "0.11.4"
 }

--- a/src/gcp_utils.py
+++ b/src/gcp_utils.py
@@ -576,32 +576,59 @@ def generate_kubeconfig_for_gke(gke_clusters, workspace_info):
         logger.warning("No GKE clusters configured or discovered")
         return
 
+    # Detect cross-project name collisions. Two GKE clusters in different
+    # projects can share the same name (e.g. "prod-cluster" in both proj-a and
+    # proj-b). The kubeconfig context/cluster/user names must be unique or the
+    # second entry silently overwrites the first. When a collision is detected,
+    # prefix the kubeconfig name with the project ID (e.g.
+    # "proj-a--prod-cluster") so both clusters are reachable. The original GKE
+    # cluster name is still passed to the Container API.
+    name_counts: dict[str, int] = {}
     for cluster in all_clusters:
-        cluster_name = cluster.get('name')
+        cn = cluster.get('name')
+        if cn:
+            name_counts[cn] = name_counts.get(cn, 0) + 1
+    collided_names = {n for n, c in name_counts.items() if c > 1}
+    if collided_names:
+        logger.info(
+            f"Disambiguating GKE clusters with cross-project name collisions: "
+            f"{collided_names}"
+        )
+
+    for cluster in all_clusters:
+        original_name = cluster.get('name')
         # Accept location, zone, or region; get_cluster treats them the same.
         location = cluster.get('location') or cluster.get('zone') or cluster.get('region')
         cluster_project_id = cluster.get('projectId') or project_id
 
-        if not cluster_name or not location:
+        if not original_name or not location:
             logger.error(
-                f"Skipping GKE cluster with missing name/location: name={cluster_name}, location={location}"
+                f"Skipping GKE cluster with missing name/location: name={original_name}, location={location}"
             )
             continue
 
+        # Disambiguate the kubeconfig context/cluster/user name when the GKE
+        # cluster name collides across projects. The original name is still used
+        # for the Container API call below.
+        if original_name in collided_names and cluster_project_id:
+            kubeconfig_name = f"{cluster_project_id}--{original_name}"
+        else:
+            kubeconfig_name = original_name
+
         try:
             endpoint, ca_cert = _fetch_gke_cluster_details(
-                client, cluster_project_id, location, cluster_name
+                client, cluster_project_id, location, original_name
             )
         except Exception as e:
             logger.error(
-                f"Skipping GKE cluster {mask_string(cluster_name)}: "
+                f"Skipping GKE cluster {mask_string(original_name)}: "
                 f"failed to fetch cluster details: {e}"
             )
             continue
 
         if not endpoint or not ca_cert:
             logger.error(
-                f"Skipping GKE cluster {mask_string(cluster_name)}: missing "
+                f"Skipping GKE cluster {mask_string(original_name)}: missing "
                 f"endpoint={endpoint is not None} / ca={ca_cert is not None}"
             )
             continue
@@ -611,7 +638,7 @@ def generate_kubeconfig_for_gke(gke_clusters, workspace_info):
         # treat GKE identically.
         extension_data = {
             'cluster_type': 'gke',
-            'cluster_name': cluster_name,
+            'cluster_name': original_name,
             'project_id': cluster_project_id,
             'location': location,
             'auth_type': auth_type,
@@ -620,12 +647,12 @@ def generate_kubeconfig_for_gke(gke_clusters, workspace_info):
         if 'defaultNamespaceLOD' in cluster:
             extension_data['defaultNamespaceLOD'] = cluster['defaultNamespaceLOD']
             logger.info(
-                f"Adding defaultNamespaceLOD to extension for cluster '{cluster_name}': "
+                f"Adding defaultNamespaceLOD to extension for cluster '{kubeconfig_name}': "
                 f"{cluster['defaultNamespaceLOD']}"
             )
 
         cluster_entry = {
-            'name': cluster_name,
+            'name': kubeconfig_name,
             'cluster': {
                 'server': f"https://{endpoint}",
                 'certificate-authority-data': ca_cert,
@@ -639,14 +666,14 @@ def generate_kubeconfig_for_gke(gke_clusters, workspace_info):
         # GKE uses short-lived OAuth bearer tokens for apiserver auth. Embed the
         # token minted above directly (the gke-gcloud-auth-plugin exec flow is
         # intentionally avoided -- that's the gcloud dependency being removed).
-        user_name = f"{cluster_name}-user"
+        user_name = f"{kubeconfig_name}-user"
         user_entry = {
             'name': user_name,
             'user': {'token': oauth_token},
         }
         context_entry = {
-            'name': cluster_name,
-            'context': {'cluster': cluster_name, 'user': user_name},
+            'name': kubeconfig_name,
+            'context': {'cluster': kubeconfig_name, 'user': user_name},
         }
 
         combined_kubeconfig['clusters'].append(cluster_entry)
@@ -654,10 +681,10 @@ def generate_kubeconfig_for_gke(gke_clusters, workspace_info):
         combined_kubeconfig['contexts'].append(context_entry)
 
         if not combined_kubeconfig['current-context']:
-            combined_kubeconfig['current-context'] = cluster_name
-            logger.info(f"Setting current context to: {cluster_name}")
+            combined_kubeconfig['current-context'] = kubeconfig_name
+            logger.info(f"Setting current context to: {kubeconfig_name}")
 
-        logger.info(f"Added kubeconfig entry for GKE cluster {mask_string(cluster_name)} in {location}")
+        logger.info(f"Added kubeconfig entry for GKE cluster {mask_string(kubeconfig_name)} in {location}")
 
     if not combined_kubeconfig['clusters']:
         logger.warning("No GKE clusters were successfully added to the kubeconfig")

--- a/src/gcp_utils.py
+++ b/src/gcp_utils.py
@@ -314,6 +314,32 @@ def _decode_service_account_key(service_account_key: Optional[str]) -> Optional[
     return text
 
 
+# ---------------------------------------------------------------------------
+# Project-ID normalization (shared by GKE auto-discovery)
+# ---------------------------------------------------------------------------
+
+def _normalize_project_ids(value) -> list[str]:
+    """Normalize a projects config value into a de-duplicated list of project IDs.
+
+    Accepts a single string, a list of strings, or None.
+    """
+    if value is None:
+        return []
+    if isinstance(value, str):
+        return [p.strip() for p in value.split(",") if p.strip()]
+    if isinstance(value, (list, tuple)):
+        out: list[str] = []
+        for item in value:
+            if isinstance(item, dict):
+                pid = item.get("projectId") or item.get("project_id") or item.get("id")
+                if pid:
+                    out.append(str(pid).strip())
+            elif item:
+                out.append(str(item).strip())
+        return out
+    return [str(value).strip()]
+
+
 # Scope every GKE credential to the full cloud-platform scope so the same token
 # works for the Container API call and for talking to the cluster apiserver.
 GKE_OAUTH_SCOPES = ["https://www.googleapis.com/auth/cloud-platform"]
@@ -477,13 +503,50 @@ def generate_kubeconfig_for_gke(gke_clusters, workspace_info):
     if auto_discover:
         logger.info("Auto-discovery enabled for GKE clusters")
         discovery_config = gke_config.get('discoveryConfig', {}) or {}
-        discovery_project = discovery_config.get('projectId') or project_id
-        discovered_clusters = discover_gke_clusters(discovery_project, client=client)
+
+        # Resolve the set of projects to enumerate. The GCP Container API
+        # ``list_clusters`` is scoped per-project (``projects/{id}/locations/-``),
+        # so to discover clusters across multiple projects we must call it once
+        # per project and merge.
+        #
+        # Priority:
+        #   1. ``discoveryConfig.projectId`` — if set, discover ONLY that project
+        #      (acts as an explicit filter). Can be a single string or a list.
+        #   2. ``cloudConfig.gcp.projects`` — discover ALL configured projects.
+        #   3. ``cloudConfig.gcp.projectId`` — single-project fallback.
+        discovery_project_ids: list[str] = []
+        discovery_project_id = discovery_config.get('projectId')
+        if discovery_project_id:
+            discovery_project_ids = _normalize_project_ids(discovery_project_id)
+        if not discovery_project_ids:
+            gcp_config = workspace_info.get('cloudConfig', {}).get('gcp', {}) or {}
+            discovery_project_ids = _normalize_project_ids(gcp_config.get('projects'))
+        if not discovery_project_ids:
+            discovery_project_ids = _normalize_project_ids(gcp_config.get('projectId'))
+        if not discovery_project_ids and project_id:
+            discovery_project_ids = [project_id]
+        if not discovery_project_ids:
+            logger.warning(
+                "GKE auto-discovery enabled but no projects configured; "
+                "set cloudConfig.gcp.projects or gkeClusters.discoveryConfig.projectId"
+            )
+
+        discovered_clusters: list[dict[str, str]] = []
+        for pid in discovery_project_ids:
+            clusters_in_project = discover_gke_clusters(pid, client=client)
+            # Tag each discovered cluster with its project so _fetch_gke_cluster_details
+            # uses the right project when the user hasn't set projectId explicitly.
+            for c in clusters_in_project:
+                c.setdefault('projectId', pid)
+            discovered_clusters.extend(clusters_in_project)
+
         # De-dupe discovered clusters already named explicitly.
         explicit_names = {c.get('name') for c in explicit_clusters}
         discovered_clusters = [c for c in discovered_clusters if c.get('name') not in explicit_names]
         all_clusters = explicit_clusters + discovered_clusters
         logger.info(
+            f"Auto-discovered GKE clusters across {len(discovery_project_ids)} project(s): "
+            f"{discovery_project_ids}. "
             f"Using {len(explicit_clusters)} explicit clusters + "
             f"{len(discovered_clusters)} discovered clusters = {len(all_clusters)} total"
         )

--- a/src/gcp_utils.py
+++ b/src/gcp_utils.py
@@ -650,6 +650,12 @@ def generate_kubeconfig_for_gke(gke_clusters, workspace_info):
                 f"Adding defaultNamespaceLOD to extension for cluster '{kubeconfig_name}': "
                 f"{cluster['defaultNamespaceLOD']}"
             )
+        if 'namespaceLODs' in cluster:
+            extension_data['namespaceLODs'] = cluster['namespaceLODs']
+            logger.info(
+                f"Adding namespaceLODs to extension for cluster '{kubeconfig_name}': "
+                f"{cluster['namespaceLODs']}"
+            )
 
         cluster_entry = {
             'name': kubeconfig_name,

--- a/src/gcp_utils.py
+++ b/src/gcp_utils.py
@@ -321,23 +321,33 @@ def _decode_service_account_key(service_account_key: Optional[str]) -> Optional[
 def _normalize_project_ids(value) -> list[str]:
     """Normalize a projects config value into a de-duplicated list of project IDs.
 
-    Accepts a single string, a list of strings, or None.
+    Accepts a single string, a list of strings, or None.  Duplicate IDs are
+    removed (preserving first-occurrence order) so we never make redundant
+    ``list_clusters`` calls.
     """
     if value is None:
         return []
     if isinstance(value, str):
-        return [p.strip() for p in value.split(",") if p.strip()]
-    if isinstance(value, (list, tuple)):
-        out: list[str] = []
+        raw = [p.strip() for p in value.split(",") if p.strip()]
+    elif isinstance(value, (list, tuple)):
+        raw: list[str] = []
         for item in value:
             if isinstance(item, dict):
                 pid = item.get("projectId") or item.get("project_id") or item.get("id")
                 if pid:
-                    out.append(str(pid).strip())
+                    raw.append(str(pid).strip())
             elif item:
-                out.append(str(item).strip())
-        return out
-    return [str(value).strip()]
+                raw.append(str(item).strip())
+    else:
+        raw = [str(value).strip()]
+    # De-duplicate while preserving order.
+    seen: set[str] = set()
+    out: list[str] = []
+    for pid in raw:
+        if pid and pid not in seen:
+            seen.add(pid)
+            out.append(pid)
+    return out
 
 
 # Scope every GKE credential to the full cloud-platform scope so the same token
@@ -540,9 +550,17 @@ def generate_kubeconfig_for_gke(gke_clusters, workspace_info):
                 c.setdefault('projectId', pid)
             discovered_clusters.extend(clusters_in_project)
 
-        # De-dupe discovered clusters already named explicitly.
-        explicit_names = {c.get('name') for c in explicit_clusters}
-        discovered_clusters = [c for c in discovered_clusters if c.get('name') not in explicit_names]
+        # De-dupe discovered clusters already named explicitly. Match on the
+        # (name, projectId) pair so an explicit cluster in project A does not
+        # suppress a discovered cluster with the same name in project B.
+        explicit_keys = {
+            (c.get('name'), c.get('projectId') or project_id)
+            for c in explicit_clusters
+        }
+        discovered_clusters = [
+            c for c in discovered_clusters
+            if (c.get('name'), c.get('projectId')) not in explicit_keys
+        ]
         all_clusters = explicit_clusters + discovered_clusters
         logger.info(
             f"Auto-discovered GKE clusters across {len(discovery_project_ids)} project(s): "

--- a/src/renderers/render_output_items.py
+++ b/src/renderers/render_output_items.py
@@ -371,8 +371,22 @@ def render(context: Context):
     context.set_property("RENDER_STATS", render_stats)
 
     sorted_items = sorted(output_items.values(), key=_slx_first_sort_key)
+    total_items = len(sorted_items)
 
-    for output_item in sorted_items:
+    for idx, output_item in enumerate(sorted_items):
+        # Report progress to the health tracker so the liveness probe can see
+        # the render phase is advancing, even on very large workspaces.
+        if idx % 25 == 0 or idx == total_items - 1:
+            try:
+                from workspace_builder.health import get_health_tracker
+                health_tracker = get_health_tracker()
+                health_tracker.update_stage(
+                    "rendering",
+                    f"render_output_items ({idx + 1}/{total_items})",
+                )
+            except Exception:
+                pass
+
         slx_dir = os.path.dirname(output_item.path)
 
         if slx_dir in failed_slx_dirs:

--- a/src/template.py
+++ b/src/template.py
@@ -22,15 +22,21 @@ logger = logging.getLogger(__name__)
 # template rendering (the Jinja2 docs explicitly support this).
 # ---------------------------------------------------------------------------
 
-_env_cache: dict[str, SandboxedEnvironment] = {}
+_env_cache: dict[Any, SandboxedEnvironment] = {}
 _env_cache_lock = threading.Lock()
 
 
 def _get_environment(template_loader_func: Optional[Callable] = None) -> SandboxedEnvironment:
     """Return a cached (or newly built) SandboxedEnvironment for the given
-    loader configuration."""
-    # Cache key: presence/absence of a custom loader is the only variable.
-    cache_key = "custom" if template_loader_func else "default"
+    loader configuration.
+
+    The cache key is the ``template_loader_func`` object itself (or ``None``
+    for the default ``FileSystemLoader``-only path). Different codecollections
+    create distinct lambda closures (each capturing its own
+    ``code_collection``), so they correctly get separate environments. The
+    cache dict holds a reference to the callable, preventing premature GC.
+    """
+    cache_key: Any = template_loader_func  # None or the callable object
     env = _env_cache.get(cache_key)
     if env is not None:
         return env

--- a/src/template.py
+++ b/src/template.py
@@ -1,5 +1,6 @@
 import logging
-from typing import Any
+import threading
+from typing import Any, Callable, Optional
 
 from jinja2.loaders import FileSystemLoader
 from jinja2.sandbox import SandboxedEnvironment
@@ -10,6 +11,48 @@ from jinja2 import Undefined
 from exceptions import WorkspaceBuilderException
 
 logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Environment cache: rebuild a Jinja2 SandboxEnvironment (with disk loaders +
+# template bytecode caching) on every render call is wasteful — for a workspace
+# with 500 output items that's 500 environment + FileSystemLoader constructions
+# and 500 template re-parses from disk. We cache one environment per loader
+# configuration so repeated render_template_file calls reuse the parsed
+# template objects. The SandboxedEnvironment is thread-safe for read-only
+# template rendering (the Jinja2 docs explicitly support this).
+# ---------------------------------------------------------------------------
+
+_env_cache: dict[str, SandboxedEnvironment] = {}
+_env_cache_lock = threading.Lock()
+
+
+def _get_environment(template_loader_func: Optional[Callable] = None) -> SandboxedEnvironment:
+    """Return a cached (or newly built) SandboxedEnvironment for the given
+    loader configuration."""
+    # Cache key: presence/absence of a custom loader is the only variable.
+    cache_key = "custom" if template_loader_func else "default"
+    env = _env_cache.get(cache_key)
+    if env is not None:
+        return env
+    with _env_cache_lock:
+        # Double-checked lock.
+        env = _env_cache.get(cache_key)
+        if env is not None:
+            return env
+        loaders = [FileSystemLoader("templates")]
+        if template_loader_func:
+            loaders.insert(0, CustomTemplateLoader(template_loader_func))
+        env = SandboxedEnvironment(
+            loader=ChoiceLoader(loaders),
+            trim_blocks=True,
+            lstrip_blocks=True,
+            undefined=CustomUndefined,
+            # Enable bytecode caching so compiled templates are reused across
+            # calls without re-parsing the .yaml source.
+            auto_reload=False,
+        )
+        _env_cache[cache_key] = env
+        return env
 
 
 class CustomUndefined(Undefined):
@@ -71,12 +114,7 @@ def render_template_file(template_file_name: str,
                          template_variables: dict[str, Any],
                          template_loader_func = None) -> str:
     try:
-        # The environment setup code should never raise an exception,
-        # but put it in the try block just to be safe...
-        loaders = [FileSystemLoader("templates")]
-        if template_loader_func:
-            loaders.insert(0, CustomTemplateLoader(template_loader_func))
-        env = SandboxedEnvironment(loader=ChoiceLoader(loaders), trim_blocks=True, lstrip_blocks=True, undefined=CustomUndefined)
+        env = _get_environment(template_loader_func)
         template = env.get_template(template_file_name)
         return template.render(**template_variables)
     except TemplateNotFound as e:

--- a/src/template.py
+++ b/src/template.py
@@ -13,51 +13,57 @@ from exceptions import WorkspaceBuilderException
 logger = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------
-# Environment cache: rebuild a Jinja2 SandboxEnvironment (with disk loaders +
-# template bytecode caching) on every render call is wasteful — for a workspace
-# with 500 output items that's 500 environment + FileSystemLoader constructions
-# and 500 template re-parses from disk. We cache one environment per loader
-# configuration so repeated render_template_file calls reuse the parsed
-# template objects. The SandboxedEnvironment is thread-safe for read-only
-# template rendering (the Jinja2 docs explicitly support this).
+# Environment cache: rebuild a Jinja2 SandboxedEnvironment (with disk loaders)
+# on every render_template_file call is wasteful — for a workspace with 500
+# output items that's 500 FileSystemLoader constructions and 500 template
+# re-parses from disk.
+#
+# We cache one environment for the DEFAULT (no custom loader) path — this
+# covers the majority of render_template_file calls (built-in templates like
+# kubernetes-auth.yaml, gcp-auth.yaml, etc.). Custom-loader paths
+# (codecollection templates) get fresh environments since each
+# generate_output_item call creates a new lambda closure, making
+# function-object-based caching O(num_output_items).
 # ---------------------------------------------------------------------------
 
-_env_cache: dict[Any, SandboxedEnvironment] = {}
+_env_cache: SandboxedEnvironment | None = None
 _env_cache_lock = threading.Lock()
 
 
 def _get_environment(template_loader_func: Optional[Callable] = None) -> SandboxedEnvironment:
-    """Return a cached (or newly built) SandboxedEnvironment for the given
-    loader configuration.
+    """Return a (possibly cached) SandboxedEnvironment.
 
-    The cache key is the ``template_loader_func`` object itself (or ``None``
-    for the default ``FileSystemLoader``-only path). Different codecollections
-    create distinct lambda closures (each capturing its own
-    ``code_collection``), so they correctly get separate environments. The
-    cache dict holds a reference to the callable, preventing premature GC.
+    Only the default loader configuration (``template_loader_func is None``)
+    is cached — it's the hot path used for every built-in template. Custom
+    loaders get fresh environments to avoid unbounded cache growth from the
+    per-output-item lambdas created by ``generate_output_item``.
     """
-    cache_key: Any = template_loader_func  # None or the callable object
-    env = _env_cache.get(cache_key)
-    if env is not None:
-        return env
-    with _env_cache_lock:
-        # Double-checked lock.
-        env = _env_cache.get(cache_key)
-        if env is not None:
-            return env
-        loaders = [FileSystemLoader("templates")]
-        if template_loader_func:
-            loaders.insert(0, CustomTemplateLoader(template_loader_func))
-        env = SandboxedEnvironment(
+    global _env_cache
+
+    if template_loader_func is not None:
+        loaders: list = [CustomTemplateLoader(template_loader_func), FileSystemLoader("templates")]
+        return SandboxedEnvironment(
             loader=ChoiceLoader(loaders),
             trim_blocks=True,
             lstrip_blocks=True,
             undefined=CustomUndefined,
-            # Enable bytecode caching so compiled templates are reused across
-            # calls without re-parsing the .yaml source.
-            auto_reload=False,
         )
-        _env_cache[cache_key] = env
+
+    # Default path — cached.
+    env = _env_cache
+    if env is not None:
+        return env
+    with _env_cache_lock:
+        env = _env_cache
+        if env is not None:
+            return env
+        env = SandboxedEnvironment(
+            loader=ChoiceLoader([FileSystemLoader("templates")]),
+            trim_blocks=True,
+            lstrip_blocks=True,
+            undefined=CustomUndefined,
+        )
+        _env_cache = env
         return env
 
 

--- a/src/templates/gcp-kubernetes-auth.yaml
+++ b/src/templates/gcp-kubernetes-auth.yaml
@@ -1,16 +1,19 @@
 {% if cluster is defined and cluster.cluster_type | default('') == "gke" and cluster.auth_type | default('') == "gcp_service_account_secret" %}
     - name: kubeconfig
-      workspaceKey: gcp:sa@kubeconfig:{{ cluster.name | default('undefined') }}/{{ cluster.zone | default(cluster.region | default('undefined')) }}
+      workspaceKey: gcp:sa@kubeconfig:{{ cluster.name | default('undefined') }}/{{ cluster.location or cluster.zone or cluster.region or 'undefined' }}
     - name: gcp_projectId
       workspaceKey: k8s:file@secret/{{ cluster.auth_secret | default('undefined') }}:projectId
     - name: gcp_serviceAccountKey
       workspaceKey: k8s:file@secret/{{ cluster.auth_secret | default('undefined') }}:serviceAccountKey
-{% elif cluster is defined and cluster.cluster_type | default('') == "gke" and cluster.auth_type | default('') == "gcp_service_account" %}
+{% elif cluster is defined and cluster.cluster_type | default('') == "gke" and (cluster.auth_type | default('') == "gcp_service_account" or cluster.auth_type | default('') == "gcp_service_account_file") %}
     - name: kubeconfig
-      workspaceKey: gcp:sa@kubeconfig:{{ cluster.name | default('undefined') }}/{{ cluster.zone | default(cluster.region | default('undefined')) }}
+      workspaceKey: gcp:sa@kubeconfig:{{ cluster.name | default('undefined') }}/{{ cluster.location or cluster.zone or cluster.region or 'undefined' }}
 {% elif cluster is defined and cluster.cluster_type | default('') == "gke" and cluster.auth_type | default('') == "gcp_adc" %}
     - name: kubeconfig
-      workspaceKey: gcp:adc@kubeconfig:{{ cluster.name | default('undefined') }}/{{ cluster.zone | default(cluster.region | default('undefined')) }}
+      workspaceKey: gcp:adc@kubeconfig:{{ cluster.name | default('undefined') }}/{{ cluster.location or cluster.zone or cluster.region or 'undefined' }}
+{% elif cluster is defined and cluster.cluster_type | default('') == "gke" %}
+    - name: kubeconfig
+      workspaceKey: gcp:adc@kubeconfig:{{ cluster.name | default('undefined') }}/{{ cluster.location or cluster.zone or cluster.region or 'undefined' }}
 {% elif custom is defined and custom.kubeconfig_secret_name | default('') != '' %}
     - name: kubeconfig
       workspaceKey: {{ custom.kubeconfig_secret_name | default('undefined') }}

--- a/src/templates/kubernetes-auth.yaml
+++ b/src/templates/kubernetes-auth.yaml
@@ -56,6 +56,25 @@
 {% elif cluster is defined and cluster.cluster_type | default('') == "eks" %}
     - name: kubeconfig
       workspaceKey: aws:cli@kubeconfig:{{ cluster.region | default('us-east-1') }}/{{ cluster.cluster_name | default('undefined') }}
+{% elif cluster is defined and cluster.cluster_type | default('') == "gke" and cluster.auth_type | default('') == "gcp_service_account_secret" %}
+    - name: kubeconfig
+      workspaceKey: gcp:sa@kubeconfig:{{ cluster.name | default('undefined') }}/{{ cluster.location or cluster.zone or cluster.region or 'undefined' }}
+    - name: gcp_projectId
+      workspaceKey: k8s:file@secret/{{ cluster.auth_secret | default('undefined') }}:projectId
+    - name: gcp_serviceAccountKey
+      workspaceKey: k8s:file@secret/{{ cluster.auth_secret | default('undefined') }}:serviceAccountKey
+{% elif cluster is defined and cluster.cluster_type | default('') == "gke" and cluster.auth_type | default('') == "gcp_service_account" %}
+    - name: kubeconfig
+      workspaceKey: gcp:sa@kubeconfig:{{ cluster.name | default('undefined') }}/{{ cluster.location or cluster.zone or cluster.region or 'undefined' }}
+{% elif cluster is defined and cluster.cluster_type | default('') == "gke" and cluster.auth_type | default('') == "gcp_service_account_file" %}
+    - name: kubeconfig
+      workspaceKey: gcp:sa@kubeconfig:{{ cluster.name | default('undefined') }}/{{ cluster.location or cluster.zone or cluster.region or 'undefined' }}
+{% elif cluster is defined and cluster.cluster_type | default('') == "gke" and cluster.auth_type | default('') == "gcp_adc" %}
+    - name: kubeconfig
+      workspaceKey: gcp:adc@kubeconfig:{{ cluster.name | default('undefined') }}/{{ cluster.location or cluster.zone or cluster.region or 'undefined' }}
+{% elif cluster is defined and cluster.cluster_type | default('') == "gke" %}
+    - name: kubeconfig
+      workspaceKey: gcp:adc@kubeconfig:{{ cluster.name | default('undefined') }}/{{ cluster.location or cluster.zone or cluster.region or 'undefined' }}
 {% elif custom is defined and custom.kubeconfig_secret_name | default('') != '' %}
     - name: kubeconfig
       workspaceKey: {{ custom.kubeconfig_secret_name | default('undefined') }}

--- a/src/test_gke_auth_templates.py
+++ b/src/test_gke_auth_templates.py
@@ -1,0 +1,240 @@
+"""
+Unit tests for GKE auth template branches in ``kubernetes-auth.yaml`` and
+``gcp-kubernetes-auth.yaml``.
+
+These pin the fix for the bug where GKE clusters discovered via
+``cloudConfig.gcp.gkeClusters`` would fall through to the generic
+``custom.kubeconfig_secret_name`` fallback in ``kubernetes-auth.yaml``
+(producing ``k8s:file@secret/kubeconfig:kubeconfig``) instead of the correct
+``gcp:adc@kubeconfig:...`` / ``gcp:sa@kubeconfig:...`` workspaceKeys.
+
+The tests also verify that ``cluster.location`` (the attribute the GKE
+kubeconfig generator actually injects via the workspace-builder extension) is
+used as the location segment, fixing the secondary bug where the templates
+only checked ``cluster.zone`` / ``cluster.region`` and rendered ``undefined``.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from typing import Any, Optional
+from unittest import TestCase
+
+_THIS_DIR = os.path.dirname(os.path.abspath(__file__))
+if _THIS_DIR not in sys.path:
+    sys.path.insert(0, _THIS_DIR)
+
+from resources import Resource, ResourceType  # noqa: E402
+from template import render_template_file  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_cluster(
+    name: str = "platform-cluster-01",
+    cluster_type: str = "gke",
+    auth_type: str = "gcp_adc",
+    auth_secret: Optional[str] = None,
+    location: str = "us-west1",
+    zone: Optional[str] = None,
+    region: Optional[str] = None,
+) -> Resource:
+    """Build a cluster ``Resource`` mirroring what ``kubeapi.py`` creates from
+    the workspace-builder kubeconfig extension injected by
+    ``generate_kubeconfig_for_gke``."""
+    attributes: dict[str, Any] = {
+        "cluster_type": cluster_type,
+        "cluster_name": name,
+        "auth_type": auth_type,
+        "location": location,
+    }
+    if auth_secret is not None:
+        attributes["auth_secret"] = auth_secret
+    if zone is not None:
+        attributes["zone"] = zone
+    if region is not None:
+        attributes["region"] = region
+    rt = ResourceType("cluster", None)
+    return Resource(name, name, rt, **attributes)
+
+
+def _render_auth_template(
+    template_name: str,
+    cluster: Optional[Resource] = None,
+    custom: Optional[dict] = None,
+    secrets: Optional[dict] = None,
+) -> str:
+    """Render an auth template with the given variables and return the
+    rendered text."""
+    template_variables: dict[str, Any] = {}
+    if cluster is not None:
+        template_variables["cluster"] = cluster
+    if custom is not None:
+        template_variables["custom"] = custom
+    if secrets is not None:
+        template_variables["secrets"] = secrets
+    return render_template_file(template_name, template_variables)
+
+
+def _extract_workspace_key(rendered: str, name: str = "kubeconfig") -> str:
+    """Extract the workspaceKey value for a given secret name from rendered text."""
+    lines = rendered.splitlines()
+    for i, line in enumerate(lines):
+        stripped = line.strip()
+        if stripped == f"- name: {name}":
+            for j in range(i + 1, min(i + 5, len(lines))):
+                key_line = lines[j].strip()
+                if key_line.startswith("workspaceKey:"):
+                    return key_line[len("workspaceKey:"):].strip()
+                if key_line.startswith("- name:"):
+                    break
+    raise ValueError(f"workspaceKey for '{name}' not found in rendered output:\n{rendered}")
+
+
+# ---------------------------------------------------------------------------
+# kubernetes-auth.yaml — GKE branches
+# ---------------------------------------------------------------------------
+
+class KubernetesAuthGkeAdcTest(TestCase):
+    """GKE + ADC should produce gcp:adc@kubeconfig, not the kubeconfig secret fallback."""
+
+    def setUp(self):
+        os.chdir(_THIS_DIR)
+
+    def test_gke_adc_renders_gcp_adc_workspacekey(self):
+        cluster = _make_cluster(auth_type="gcp_adc", location="us-west1")
+        custom = {"kubeconfig_secret_name": "k8s:file@secret/kubeconfig:kubeconfig"}
+        rendered = _render_auth_template("kubernetes-auth.yaml", cluster=cluster, custom=custom)
+        key = _extract_workspace_key(rendered)
+        self.assertEqual(key, "gcp:adc@kubeconfig:platform-cluster-01/us-west1")
+
+    def test_gke_adc_does_not_fall_through_to_kubeconfig_secret(self):
+        """The exact regression: Helm default kubeconfig_secret_name must NOT be used."""
+        cluster = _make_cluster(auth_type="gcp_adc")
+        custom = {"kubeconfig_secret_name": "k8s:file@secret/kubeconfig:kubeconfig"}
+        rendered = _render_auth_template("kubernetes-auth.yaml", cluster=cluster, custom=custom)
+        key = _extract_workspace_key(rendered)
+        self.assertNotIn("k8s:file@secret/kubeconfig", key)
+        self.assertIn("gcp:adc@kubeconfig", key)
+
+    def test_gke_adc_location_falls_back_to_zone(self):
+        cluster = _make_cluster(auth_type="gcp_adc", location=None, zone="us-central1-a")
+        rendered = _render_auth_template("kubernetes-auth.yaml", cluster=cluster)
+        key = _extract_workspace_key(rendered)
+        self.assertEqual(key, "gcp:adc@kubeconfig:platform-cluster-01/us-central1-a")
+
+
+class KubernetesAuthGkeServiceAccountTest(TestCase):
+    """GKE + service account variants."""
+
+    def setUp(self):
+        os.chdir(_THIS_DIR)
+
+    def test_gke_service_account_renders_gcp_sa_workspacekey(self):
+        cluster = _make_cluster(auth_type="gcp_service_account", location="us-east1")
+        rendered = _render_auth_template("kubernetes-auth.yaml", cluster=cluster)
+        key = _extract_workspace_key(rendered)
+        self.assertEqual(key, "gcp:sa@kubeconfig:platform-cluster-01/us-east1")
+
+    def test_gke_service_account_file_renders_gcp_sa_workspacekey(self):
+        cluster = _make_cluster(auth_type="gcp_service_account_file", location="us-east1")
+        rendered = _render_auth_template("kubernetes-auth.yaml", cluster=cluster)
+        key = _extract_workspace_key(rendered)
+        self.assertEqual(key, "gcp:sa@kubeconfig:platform-cluster-01/us-east1")
+
+    def test_gke_service_account_secret_renders_sa_plus_secret_refs(self):
+        cluster = _make_cluster(
+            auth_type="gcp_service_account_secret",
+            auth_secret="gcp-prod-credentials",
+            location="us-west1",
+        )
+        rendered = _render_auth_template("kubernetes-auth.yaml", cluster=cluster)
+        kubeconfig_key = _extract_workspace_key(rendered, "kubeconfig")
+        self.assertEqual(kubeconfig_key, "gcp:sa@kubeconfig:platform-cluster-01/us-west1")
+        project_key = _extract_workspace_key(rendered, "gcp_projectId")
+        self.assertEqual(project_key, "k8s:file@secret/gcp-prod-credentials:projectId")
+        sa_key = _extract_workspace_key(rendered, "gcp_serviceAccountKey")
+        self.assertEqual(sa_key, "k8s:file@secret/gcp-prod-credentials:serviceAccountKey")
+
+
+class KubernetesAuthGkeCatchAllTest(TestCase):
+    """A GKE cluster with an unrecognized auth_type should fall to the gcp:adc
+    catch-all branch, not the generic kubeconfig_secret_name fallback."""
+
+    def setUp(self):
+        os.chdir(_THIS_DIR)
+
+    def test_gke_unknown_auth_type_uses_adc_catch_all(self):
+        cluster = _make_cluster(auth_type="some_future_auth", location="us-west1")
+        custom = {"kubeconfig_secret_name": "k8s:file@secret/kubeconfig:kubeconfig"}
+        rendered = _render_auth_template("kubernetes-auth.yaml", cluster=cluster, custom=custom)
+        key = _extract_workspace_key(rendered)
+        self.assertIn("gcp:adc@kubeconfig", key)
+        self.assertNotIn("k8s:file@secret/kubeconfig", key)
+
+
+class KubernetesAuthNonGkeFallbackTest(TestCase):
+    """Non-GKE clusters should still fall through to the generic fallback."""
+
+    def setUp(self):
+        os.chdir(_THIS_DIR)
+
+    def test_no_cluster_uses_kubeconfig_secret_name(self):
+        custom = {"kubeconfig_secret_name": "k8s:file@secret/kubeconfig:kubeconfig"}
+        rendered = _render_auth_template("kubernetes-auth.yaml", cluster=None, custom=custom)
+        key = _extract_workspace_key(rendered)
+        self.assertEqual(key, "k8s:file@secret/kubeconfig:kubeconfig")
+
+    def test_aks_still_works(self):
+        cluster = _make_cluster(
+            name="aks-cluster-1",
+            cluster_type="aks",
+            auth_type="azure_managed_identity",
+            location=None,
+        )
+        cluster.resource_group = "rg-aks-1"
+        rendered = _render_auth_template("kubernetes-auth.yaml", cluster=cluster)
+        key = _extract_workspace_key(rendered)
+        self.assertEqual(key, "azure:identity@kubeconfig:rg-aks-1/aks-cluster-1")
+
+
+# ---------------------------------------------------------------------------
+# gcp-kubernetes-auth.yaml — location fix
+# ---------------------------------------------------------------------------
+
+class GcpKubernetesAuthLocationTest(TestCase):
+    """Verify gcp-kubernetes-auth.yaml uses cluster.location (not just zone/region)."""
+
+    def setUp(self):
+        os.chdir(_THIS_DIR)
+
+    def test_gcp_adc_uses_location(self):
+        cluster = _make_cluster(auth_type="gcp_adc", location="us-west1")
+        rendered = _render_auth_template("gcp-kubernetes-auth.yaml", cluster=cluster)
+        key = _extract_workspace_key(rendered)
+        self.assertEqual(key, "gcp:adc@kubeconfig:platform-cluster-01/us-west1")
+
+    def test_gcp_sa_uses_location(self):
+        cluster = _make_cluster(auth_type="gcp_service_account", location="us-east1")
+        rendered = _render_auth_template("gcp-kubernetes-auth.yaml", cluster=cluster)
+        key = _extract_workspace_key(rendered)
+        self.assertEqual(key, "gcp:sa@kubeconfig:platform-cluster-01/us-east1")
+
+    def test_gcp_sa_secret_uses_location(self):
+        cluster = _make_cluster(
+            auth_type="gcp_service_account_secret",
+            auth_secret="gcp-creds",
+            location="us-central1",
+        )
+        rendered = _render_auth_template("gcp-kubernetes-auth.yaml", cluster=cluster)
+        key = _extract_workspace_key(rendered, "kubeconfig")
+        self.assertEqual(key, "gcp:sa@kubeconfig:platform-cluster-01/us-central1")
+
+    def test_gcp_adc_location_falls_back_to_zone(self):
+        cluster = _make_cluster(auth_type="gcp_adc", location=None, zone="us-central1-a")
+        rendered = _render_auth_template("gcp-kubernetes-auth.yaml", cluster=cluster)
+        key = _extract_workspace_key(rendered)
+        self.assertEqual(key, "gcp:adc@kubeconfig:platform-cluster-01/us-central1-a")

--- a/src/test_gke_multi_project_discovery.py
+++ b/src/test_gke_multi_project_discovery.py
@@ -494,3 +494,203 @@ class ClusterNameCollisionTest(TestCase):
         c.name = name
         c.location = location
         return c
+
+
+# ---------------------------------------------------------------------------
+# LOD key disambiguation for colliding cluster names
+# ---------------------------------------------------------------------------
+
+class ClusterLodKeyDisambiguationTest(TestCase):
+    """When cross-project name collisions are disambiguated (kubeconfig context
+    ``proj-a--prod``), the per-cluster LOD settings must be injected into the
+    kubeconfig extension so ``build_cluster_lod_maps`` registers them under the
+    disambiguated name, not just the original YAML name.
+
+    Without this, the kubeapi indexer looks up LOD by the disambiguated context
+    name (``proj-a--prod``), misses the map, and skips per-cluster LOD handling.
+    """
+
+    def test_explicit_cluster_with_lod_and_collision_injects_into_extension(self):
+        """An explicit cluster with defaultNamespaceLOD + namespaceLODs that
+        collides with another project's cluster must carry those LOD settings
+        in the kubeconfig workspace-builder extension, keyed under the
+        disambiguated name."""
+        import gcp_utils
+
+        workspace_info = {
+            "cloudConfig": {
+                "gcp": {
+                    "projects": ["proj-a", "proj-b"],
+                    "gkeClusters": {
+                        "autoDiscover": False,
+                        "clusters": [
+                            {
+                                "name": "prod",
+                                "location": "us-west1",
+                                "projectId": "proj-a",
+                                "defaultNamespaceLOD": "basic",
+                                "namespaceLODs": {"kube-system": "none"},
+                            },
+                            {
+                                "name": "prod",
+                                "location": "us-east1",
+                                "projectId": "proj-b",
+                                "defaultNamespaceLOD": "detailed",
+                            },
+                        ],
+                    },
+                }
+            }
+        }
+
+        gcp_config = workspace_info["cloudConfig"]["gcp"]
+        gke_clusters = gcp_config["gkeClusters"]["clusters"]
+
+        mock_client = MagicMock()
+        captured_config = {}
+        original_write = gcp_utils.yaml.dump
+
+        def capture_write(data, stream=None, **kwargs):
+            if isinstance(data, dict) and 'clusters' in data and 'contexts' in data:
+                captured_config.update(data)
+            if stream:
+                return original_write(data, stream, **kwargs)
+            return original_write(data, **kwargs)
+
+        with (
+            patch("gcp_utils.get_gcp_credential", return_value=("proj-a", None, "gcp_adc", None)),
+            patch("gcp_utils._decode_service_account_key", return_value=None),
+            patch("gcp_utils._build_gke_credentials", return_value=MagicMock()),
+            patch("gcp_utils._refresh_gke_token", return_value="fake-token"),
+            patch("gcp_utils._new_cluster_manager_client", return_value=mock_client),
+            patch("gcp_utils._fetch_gke_cluster_details", return_value=("1.2.3.4", "fake-ca")),
+            patch("gcp_utils.mask_string", side_effect=lambda x: x),
+            patch("gcp_utils.yaml.dump", side_effect=capture_write),
+        ):
+            gcp_utils.generate_kubeconfig_for_gke(gke_clusters, workspace_info)
+
+        context_names = [c['name'] for c in captured_config.get('contexts', [])]
+        self.assertIn("proj-a--prod", context_names)
+        self.assertIn("proj-b--prod", context_names)
+
+        for cluster_entry in captured_config.get('clusters', []):
+            if cluster_entry['name'] == 'proj-a--prod':
+                extensions = cluster_entry['cluster'].get('extensions', [])
+                for ext in extensions:
+                    if ext.get('name') == 'workspace-builder':
+                        ext_data = ext.get('extension', {})
+                        self.assertEqual(ext_data.get('defaultNamespaceLOD'), 'basic')
+                        self.assertEqual(ext_data.get('namespaceLODs'), {'kube-system': 'none'})
+                        break
+                else:
+                    self.fail("No workspace-builder extension found for proj-a--prod")
+
+        for cluster_entry in captured_config.get('clusters', []):
+            if cluster_entry['name'] == 'proj-b--prod':
+                extensions = cluster_entry['cluster'].get('extensions', [])
+                for ext in extensions:
+                    if ext.get('name') == 'workspace-builder':
+                        ext_data = ext.get('extension', {})
+                        self.assertEqual(ext_data.get('defaultNamespaceLOD'), 'detailed')
+                        break
+                else:
+                    self.fail("No workspace-builder extension found for proj-b--prod")
+
+    def test_build_cluster_lod_maps_finds_disambiguated_name(self):
+        """End-to-end: build_cluster_lod_maps must find the LOD settings for a
+        disambiguated cluster name via the kubeconfig extension, even when the
+        explicit config entry is keyed under the original name.
+
+        This test re-implements the core logic of build_cluster_lod_maps inline
+        to avoid importing kubeapi.py (which has heavy kubernetes/robot
+        dependencies). The real function is identical; this tests the contract.
+        """
+        PER_CLUSTER_LOD_TYPES = ("aks", "gke", "eks")
+
+        cloud_config = {
+            "gcp": {
+                "gkeClusters": {
+                    "clusters": [
+                        {
+                            "name": "prod",
+                            "location": "us-west1",
+                            "projectId": "proj-a",
+                            "defaultNamespaceLOD": "basic",
+                            "namespaceLODs": {"kube-system": "none"},
+                        },
+                    ]
+                }
+            }
+        }
+
+        kubeconfig_clusters = [
+            {
+                "name": "proj-a--prod",
+                "cluster": {
+                    "server": "https://1.2.3.4",
+                    "extensions": [
+                        {
+                            "name": "workspace-builder",
+                            "extension": {
+                                "cluster_type": "gke",
+                                "cluster_name": "prod",
+                                "project_id": "proj-a",
+                                "location": "us-west1",
+                                "defaultNamespaceLOD": "basic",
+                                "namespaceLODs": {"kube-system": "none"},
+                            },
+                        }
+                    ],
+                },
+            }
+        ]
+
+        default_lod = "detailed"
+        namespace_lods: dict = {}
+        cluster_lod_settings: dict = {}
+        cluster_namespace_lods: dict = {}
+
+        # --- Replicate build_cluster_lod_maps _load_explicit ---
+        gcp_settings = cloud_config.get("gcp", {}) or {}
+        clusters_config = (gcp_settings.get("gkeClusters", {}) or {}).get("clusters", [])
+        for cluster_cfg in clusters_config:
+            cfg_name = cluster_cfg.get("name")
+            if not cfg_name:
+                continue
+            cluster_lod_settings[cfg_name] = cluster_cfg.get("defaultNamespaceLOD", default_lod)
+            ns_lods = cluster_cfg.get("namespaceLODs", {})
+            if ns_lods:
+                cluster_namespace_lods[cfg_name] = ns_lods
+                namespace_lods.update(ns_lods)
+
+        # --- Replicate build_cluster_lod_maps extension scanning ---
+        for cluster in kubeconfig_clusters:
+            cluster_name = cluster.get('name')
+            cluster_details = cluster.get('cluster', {})
+            extensions = cluster_details.get('extensions', [])
+            for ext in extensions:
+                if ext.get('name') == 'workspace-builder':
+                    extension_details = ext.get('extension', {})
+                    if extension_details.get('cluster_type') in PER_CLUSTER_LOD_TYPES:
+                        if 'defaultNamespaceLOD' in extension_details:
+                            cluster_lod_settings[cluster_name] = extension_details['defaultNamespaceLOD']
+                        if 'namespaceLODs' in extension_details:
+                            cluster_namespace_lods[cluster_name] = extension_details['namespaceLODs']
+                            namespace_lods.update(extension_details['namespaceLODs'])
+                    break
+
+        # The disambiguated name must be in the LOD settings (via extension)
+        self.assertIn("proj-a--prod", cluster_lod_settings)
+        self.assertEqual(cluster_lod_settings["proj-a--prod"], "basic")
+        # The original name is also present (from _load_explicit) but that's OK
+        self.assertIn("prod", cluster_lod_settings)
+
+        # namespaceLODs must also be registered under the disambiguated name
+        self.assertIn("proj-a--prod", cluster_namespace_lods)
+        self.assertEqual(cluster_namespace_lods["proj-a--prod"], {"kube-system": "none"})
+
+    def _make_cluster_obj(self, name, location):
+        c = MagicMock()
+        c.name = name
+        c.location = location
+        return c

--- a/src/test_gke_multi_project_discovery.py
+++ b/src/test_gke_multi_project_discovery.py
@@ -1,0 +1,283 @@
+"""
+Unit tests for multi-project GKE auto-discovery in ``gcp_utils.py``.
+
+These pin the fix for the bug where ``gkeClusters.autoDiscover: true`` only
+discovered clusters in a single project (the first project from
+``cloudConfig.gcp.projects`` or ``discoveryConfig.projectId``), even when
+multiple projects were configured.
+
+The GCP Container API ``list_clusters`` is scoped per-project
+(``projects/{id}/locations/-``), so to discover clusters across multiple
+projects we must call it once per project and merge the results.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from unittest import TestCase
+from unittest.mock import MagicMock, patch
+
+_THIS_DIR = os.path.dirname(os.path.abspath(__file__))
+if _THIS_DIR not in sys.path:
+    sys.path.insert(0, _THIS_DIR)
+
+# gcp_utils -> utils -> kubernetes; stub the kubernetes module so the import
+# doesn't fail in environments without the kubernetes Python package.
+for _mod in ("kubernetes", "kubernetes.dynamic", "kubernetes.dynamic.resource"):
+    if _mod not in sys.modules:
+        sys.modules[_mod] = MagicMock()
+
+from gcp_utils import _normalize_project_ids, discover_gke_clusters  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# _normalize_project_ids
+# ---------------------------------------------------------------------------
+
+class NormalizeProjectIdsTest(TestCase):
+    def test_single_string(self):
+        self.assertEqual(_normalize_project_ids("my-project"), ["my-project"])
+
+    def test_comma_separated_string(self):
+        self.assertEqual(
+            _normalize_project_ids("proj-a, proj-b,proj-c"),
+            ["proj-a", "proj-b", "proj-c"],
+        )
+
+    def test_list_of_strings(self):
+        self.assertEqual(
+            _normalize_project_ids(["proj-a", "proj-b"]),
+            ["proj-a", "proj-b"],
+        )
+
+    def test_list_of_dicts(self):
+        self.assertEqual(
+            _normalize_project_ids([
+                {"projectId": "proj-a"},
+                {"project_id": "proj-b"},
+            ]),
+            ["proj-a", "proj-b"],
+        )
+
+    def test_none(self):
+        self.assertEqual(_normalize_project_ids(None), [])
+
+    def test_empty_list(self):
+        self.assertEqual(_normalize_project_ids([]), [])
+
+    def test_strips_whitespace(self):
+        self.assertEqual(
+            _normalize_project_ids(["  proj-a  ", " proj-b "]),
+            ["proj-a", "proj-b"],
+        )
+
+
+# ---------------------------------------------------------------------------
+# discover_gke_clusters — per-project scoping
+# ---------------------------------------------------------------------------
+
+class DiscoverGkeClustersTest(TestCase):
+    """Verify ``discover_gke_clusters`` only queries the given project and
+    returns the right cluster dicts."""
+
+    def _make_mock_client(self, clusters):
+        """Build a mock ClusterManagerClient whose list_clusters returns the
+        given cluster objects."""
+        mock_response = MagicMock()
+        mock_response.clusters = clusters
+        mock_client = MagicMock()
+        mock_client.list_clusters.return_value = mock_response
+        return mock_client
+
+    def _make_cluster_obj(self, name, location):
+        c = MagicMock()
+        c.name = name
+        c.location = location
+        return c
+
+    def test_single_project(self):
+        clusters = [self._make_cluster_obj("cluster-a", "us-west1")]
+        client = self._make_mock_client(clusters)
+        result = discover_gke_clusters("proj-a", client=client)
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0]["name"], "cluster-a")
+        self.assertEqual(result[0]["location"], "us-west1")
+        # Verify the parent path was scoped to proj-a
+        call_args = client.list_clusters.call_args
+        self.assertEqual(call_args.kwargs["parent"], "projects/proj-a/locations/-")
+
+    def test_empty_project_returns_empty(self):
+        client = self._make_mock_client([])
+        result = discover_gke_clusters("proj-empty", client=client)
+        self.assertEqual(result, [])
+
+    def test_filters_out_missing_name_or_location(self):
+        clusters = [
+            self._make_cluster_obj("good-cluster", "us-west1"),
+            self._make_cluster_obj(None, "us-west1"),
+            self._make_cluster_obj("no-location", None),
+        ]
+        client = self._make_mock_client(clusters)
+        result = discover_gke_clusters("proj-a", client=client)
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0]["name"], "good-cluster")
+
+
+# ---------------------------------------------------------------------------
+# Multi-project auto-discovery integration
+# ---------------------------------------------------------------------------
+
+class MultiProjectAutoDiscoveryTest(TestCase):
+    """Verify that ``generate_kubeconfig_for_gke`` calls
+    ``discover_gke_clusters`` once per configured project when autoDiscover is
+    true, and merges the results."""
+
+    def test_multi_project_discovery_calls_list_per_project(self):
+        """The core regression: multiple projects must each get a list_clusters call."""
+        from gcp_utils import generate_kubeconfig_for_gke
+
+        workspace_info = {
+            "cloudConfig": {
+                "gcp": {
+                    "projects": ["proj-beta", "proj-staging"],
+                    "gkeClusters": {
+                        "autoDiscover": True,
+                    },
+                }
+            }
+        }
+
+        # Mock the credential resolution + client building so we never touch GCP.
+        mock_client = MagicMock()
+
+        # Track which project parents were queried.
+        queried_parents = []
+
+        def mock_list_clusters(parent=None):
+            queried_parents.append(parent)
+            resp = MagicMock()
+            if "proj-beta" in parent:
+                resp.clusters = [self._make_cluster_obj("beta-cluster", "us-west1")]
+            elif "proj-staging" in parent:
+                resp.clusters = [self._make_cluster_obj("staging-cluster", "us-east1")]
+            else:
+                resp.clusters = []
+            return resp
+
+        mock_client.list_clusters.side_effect = mock_list_clusters
+
+        with (
+            patch("gcp_utils.get_gcp_credential", return_value=("proj-beta", None, "gcp_adc", None)),
+            patch("gcp_utils._decode_service_account_key", return_value=None),
+            patch("gcp_utils._build_gke_credentials", return_value=MagicMock()),
+            patch("gcp_utils._refresh_gke_token", return_value="fake-token"),
+            patch("gcp_utils._new_cluster_manager_client", return_value=mock_client),
+            patch("gcp_utils._fetch_gke_cluster_details", return_value=("1.2.3.4", "fake-ca")),
+            patch("gcp_utils.mask_string", side_effect=lambda x: x),
+        ):
+            generate_kubeconfig_for_gke([], workspace_info)
+
+        # Both projects must have been queried
+        self.assertEqual(len(queried_parents), 2)
+        self.assertIn("projects/proj-beta/locations/-", queried_parents)
+        self.assertIn("projects/proj-staging/locations/-", queried_parents)
+
+    def test_discovery_config_project_id_filters_to_single_project(self):
+        """When discoveryConfig.projectId is set, only that project is queried."""
+        from gcp_utils import generate_kubeconfig_for_gke
+
+        workspace_info = {
+            "cloudConfig": {
+                "gcp": {
+                    "projects": ["proj-beta", "proj-staging"],
+                    "gkeClusters": {
+                        "autoDiscover": True,
+                        "discoveryConfig": {
+                            "projectId": "proj-beta",
+                        },
+                    },
+                }
+            }
+        }
+
+        mock_client = MagicMock()
+        queried_parents = []
+
+        def mock_list_clusters(parent=None):
+            queried_parents.append(parent)
+            resp = MagicMock()
+            resp.clusters = []
+            return resp
+
+        mock_client.list_clusters.side_effect = mock_list_clusters
+
+        with (
+            patch("gcp_utils.get_gcp_credential", return_value=("proj-beta", None, "gcp_adc", None)),
+            patch("gcp_utils._decode_service_account_key", return_value=None),
+            patch("gcp_utils._build_gke_credentials", return_value=MagicMock()),
+            patch("gcp_utils._refresh_gke_token", return_value="fake-token"),
+            patch("gcp_utils._new_cluster_manager_client", return_value=mock_client),
+            patch("gcp_utils._fetch_gke_cluster_details", return_value=("1.2.3.4", "fake-ca")),
+            patch("gcp_utils.mask_string", side_effect=lambda x: x),
+        ):
+            generate_kubeconfig_for_gke([], workspace_info)
+
+        self.assertEqual(len(queried_parents), 1)
+        self.assertEqual(queried_parents[0], "projects/proj-beta/locations/-")
+
+    def test_discovered_clusters_tagged_with_project_id(self):
+        """Auto-discovered clusters must carry their projectId so
+        _fetch_gke_cluster_details queries the right project."""
+        from gcp_utils import generate_kubeconfig_for_gke
+
+        workspace_info = {
+            "cloudConfig": {
+                "gcp": {
+                    "projects": ["proj-beta", "proj-staging"],
+                    "gkeClusters": {"autoDiscover": True},
+                }
+            }
+        }
+
+        mock_client = MagicMock()
+
+        def mock_list_clusters(parent=None):
+            resp = MagicMock()
+            if "proj-beta" in parent:
+                resp.clusters = [self._make_cluster_obj("beta-cluster", "us-west1")]
+            elif "proj-staging" in parent:
+                resp.clusters = [self._make_cluster_obj("staging-cluster", "us-east1")]
+            else:
+                resp.clusters = []
+            return resp
+
+        mock_client.list_clusters.side_effect = mock_list_clusters
+
+        fetched_args = []
+
+        def mock_fetch(client, project_id, location, cluster_name):
+            fetched_args.append((project_id, location, cluster_name))
+            return ("1.2.3.4", "fake-ca")
+
+        with (
+            patch("gcp_utils.get_gcp_credential", return_value=("proj-beta", None, "gcp_adc", None)),
+            patch("gcp_utils._decode_service_account_key", return_value=None),
+            patch("gcp_utils._build_gke_credentials", return_value=MagicMock()),
+            patch("gcp_utils._refresh_gke_token", return_value="fake-token"),
+            patch("gcp_utils._new_cluster_manager_client", return_value=mock_client),
+            patch("gcp_utils._fetch_gke_cluster_details", side_effect=mock_fetch),
+            patch("gcp_utils.mask_string", side_effect=lambda x: x),
+        ):
+            generate_kubeconfig_for_gke([], workspace_info)
+
+        # Each cluster must be fetched with its own project ID
+        projects_fetched = {args[0] for args in fetched_args}
+        self.assertIn("proj-beta", projects_fetched)
+        self.assertIn("proj-staging", projects_fetched)
+
+    def _make_cluster_obj(self, name, location):
+        c = MagicMock()
+        c.name = name
+        c.location = location
+        return c

--- a/src/test_gke_multi_project_discovery.py
+++ b/src/test_gke_multi_project_discovery.py
@@ -72,6 +72,24 @@ class NormalizeProjectIdsTest(TestCase):
             ["proj-a", "proj-b"],
         )
 
+    def test_deduplicates(self):
+        self.assertEqual(
+            _normalize_project_ids(["proj-a", "proj-b", "proj-a"]),
+            ["proj-a", "proj-b"],
+        )
+
+    def test_deduplicates_comma_separated(self):
+        self.assertEqual(
+            _normalize_project_ids("proj-a, proj-b, proj-a"),
+            ["proj-a", "proj-b"],
+        )
+
+    def test_deduplicates_preserves_order(self):
+        self.assertEqual(
+            _normalize_project_ids(["proj-c", "proj-a", "proj-b", "proj-a", "proj-c"]),
+            ["proj-c", "proj-a", "proj-b"],
+        )
+
 
 # ---------------------------------------------------------------------------
 # discover_gke_clusters — per-project scoping
@@ -275,6 +293,201 @@ class MultiProjectAutoDiscoveryTest(TestCase):
         projects_fetched = {args[0] for args in fetched_args}
         self.assertIn("proj-beta", projects_fetched)
         self.assertIn("proj-staging", projects_fetched)
+
+    def _make_cluster_obj(self, name, location):
+        c = MagicMock()
+        c.name = name
+        c.location = location
+        return c
+
+
+# ---------------------------------------------------------------------------
+# Cross-project cluster name collision disambiguation
+# ---------------------------------------------------------------------------
+
+class ClusterNameCollisionTest(TestCase):
+    """When two projects both contain a cluster with the same name, the
+    kubeconfig context/cluster/user names must be disambiguated by prefixing
+    with the project ID so neither entry is silently overwritten."""
+
+    def test_same_name_different_projects_disambiguated(self):
+        """Two clusters named 'prod-cluster' in proj-a and proj-b must produce
+        distinct kubeconfig context names."""
+        import gcp_utils
+
+        workspace_info = {
+            "cloudConfig": {
+                "gcp": {
+                    "projects": ["proj-a", "proj-b"],
+                    "gkeClusters": {"autoDiscover": True},
+                }
+            }
+        }
+
+        mock_client = MagicMock()
+
+        def mock_list_clusters(parent=None):
+            resp = MagicMock()
+            if "proj-a" in parent:
+                resp.clusters = [self._make_cluster_obj("prod-cluster", "us-west1")]
+            elif "proj-b" in parent:
+                resp.clusters = [self._make_cluster_obj("prod-cluster", "us-east1")]
+            else:
+                resp.clusters = []
+            return resp
+
+        mock_client.list_clusters.side_effect = mock_list_clusters
+
+        captured_config = {}
+        original_write = gcp_utils.yaml.dump
+
+        def capture_write(data, stream=None, **kwargs):
+            if isinstance(data, dict) and 'clusters' in data and 'contexts' in data:
+                captured_config.update(data)
+            if stream:
+                return original_write(data, stream, **kwargs)
+            return original_write(data, **kwargs)
+
+        with (
+            patch("gcp_utils.get_gcp_credential", return_value=("proj-a", None, "gcp_adc", None)),
+            patch("gcp_utils._decode_service_account_key", return_value=None),
+            patch("gcp_utils._build_gke_credentials", return_value=MagicMock()),
+            patch("gcp_utils._refresh_gke_token", return_value="fake-token"),
+            patch("gcp_utils._new_cluster_manager_client", return_value=mock_client),
+            patch("gcp_utils._fetch_gke_cluster_details", return_value=("1.2.3.4", "fake-ca")),
+            patch("gcp_utils.mask_string", side_effect=lambda x: x),
+            patch("gcp_utils.yaml.dump", side_effect=capture_write),
+        ):
+            gcp_utils.generate_kubeconfig_for_gke([], workspace_info)
+
+        context_names = [c['name'] for c in captured_config.get('contexts', [])]
+        cluster_names = [c['name'] for c in captured_config.get('clusters', [])]
+
+        # Both clusters must be present (no silent overwrite)
+        self.assertEqual(len(context_names), 2, f"Expected 2 contexts, got {context_names}")
+        self.assertEqual(len(cluster_names), 2, f"Expected 2 clusters, got {cluster_names}")
+
+        # Context names must be disambiguated with projectId prefix
+        self.assertIn("proj-a--prod-cluster", context_names)
+        self.assertIn("proj-b--prod-cluster", context_names)
+
+        # No duplicate names
+        self.assertEqual(len(set(context_names)), 2)
+        self.assertEqual(len(set(cluster_names)), 2)
+
+    def test_unique_names_not_prefixed(self):
+        """Clusters with unique names must NOT be prefixed with projectId."""
+        import gcp_utils
+
+        workspace_info = {
+            "cloudConfig": {
+                "gcp": {
+                    "projects": ["proj-a", "proj-b"],
+                    "gkeClusters": {"autoDiscover": True},
+                }
+            }
+        }
+
+        mock_client = MagicMock()
+
+        def mock_list_clusters(parent=None):
+            resp = MagicMock()
+            if "proj-a" in parent:
+                resp.clusters = [self._make_cluster_obj("alpha-cluster", "us-west1")]
+            elif "proj-b" in parent:
+                resp.clusters = [self._make_cluster_obj("beta-cluster", "us-east1")]
+            else:
+                resp.clusters = []
+            return resp
+
+        mock_client.list_clusters.side_effect = mock_list_clusters
+
+        captured_config = {}
+        original_write = gcp_utils.yaml.dump
+
+        def capture_write(data, stream=None, **kwargs):
+            if isinstance(data, dict) and 'clusters' in data and 'contexts' in data:
+                captured_config.update(data)
+            if stream:
+                return original_write(data, stream, **kwargs)
+            return original_write(data, **kwargs)
+
+        with (
+            patch("gcp_utils.get_gcp_credential", return_value=("proj-a", None, "gcp_adc", None)),
+            patch("gcp_utils._decode_service_account_key", return_value=None),
+            patch("gcp_utils._build_gke_credentials", return_value=MagicMock()),
+            patch("gcp_utils._refresh_gke_token", return_value="fake-token"),
+            patch("gcp_utils._new_cluster_manager_client", return_value=mock_client),
+            patch("gcp_utils._fetch_gke_cluster_details", return_value=("1.2.3.4", "fake-ca")),
+            patch("gcp_utils.mask_string", side_effect=lambda x: x),
+            patch("gcp_utils.yaml.dump", side_effect=capture_write),
+        ):
+            gcp_utils.generate_kubeconfig_for_gke([], workspace_info)
+
+        context_names = [c['name'] for c in captured_config.get('contexts', [])]
+        # Unique names should NOT be prefixed
+        self.assertIn("alpha-cluster", context_names)
+        self.assertIn("beta-cluster", context_names)
+        self.assertNotIn("proj-a--alpha-cluster", context_names)
+
+    def test_explicit_and_discovered_same_name_different_project_not_deduped(self):
+        """An explicit cluster 'prod' in proj-a should NOT suppress a discovered
+        cluster 'prod' in proj-b. De-dup must match on (name, projectId)."""
+        from gcp_utils import generate_kubeconfig_for_gke
+
+        workspace_info = {
+            "cloudConfig": {
+                "gcp": {
+                    "projects": ["proj-a", "proj-b"],
+                    "gkeClusters": {"autoDiscover": True},
+                }
+            }
+        }
+
+        explicit_clusters = [
+            {"name": "prod", "location": "us-west1", "projectId": "proj-a"},
+        ]
+
+        mock_client = MagicMock()
+
+        def mock_list_clusters(parent=None):
+            resp = MagicMock()
+            if "proj-a" in parent:
+                resp.clusters = [self._make_cluster_obj("prod", "us-west1")]
+            elif "proj-b" in parent:
+                resp.clusters = [self._make_cluster_obj("prod", "us-east1")]
+            else:
+                resp.clusters = []
+            return resp
+
+        mock_client.list_clusters.side_effect = mock_list_clusters
+
+        fetched_args = []
+
+        def mock_fetch(client, project_id, location, cluster_name):
+            fetched_args.append((project_id, location, cluster_name))
+            return ("1.2.3.4", "fake-ca")
+
+        with (
+            patch("gcp_utils.get_gcp_credential", return_value=("proj-a", None, "gcp_adc", None)),
+            patch("gcp_utils._decode_service_account_key", return_value=None),
+            patch("gcp_utils._build_gke_credentials", return_value=MagicMock()),
+            patch("gcp_utils._refresh_gke_token", return_value="fake-token"),
+            patch("gcp_utils._new_cluster_manager_client", return_value=mock_client),
+            patch("gcp_utils._fetch_gke_cluster_details", side_effect=mock_fetch),
+            patch("gcp_utils.mask_string", side_effect=lambda x: x),
+        ):
+            generate_kubeconfig_for_gke(explicit_clusters, workspace_info)
+
+        # The explicit cluster (proj-a/prod) should suppress the discovered
+        # cluster in proj-a (same name + same project), but NOT the one in
+        # proj-b (same name, different project).
+        fetch_keys = {(p, n) for p, loc, n in fetched_args}
+        self.assertIn(("proj-a", "prod"), fetch_keys)
+        self.assertIn(("proj-b", "prod"), fetch_keys)
+        # proj-a/prod should only be fetched once (explicit, not re-discovered)
+        proj_a_prod_count = sum(1 for p, loc, n in fetched_args if p == "proj-a" and n == "prod")
+        self.assertEqual(proj_a_prod_count, 1)
 
     def _make_cluster_obj(self, name, location):
         c = MagicMock()

--- a/src/workspace_builder/api.py
+++ b/src/workspace_builder/api.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import threading
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
@@ -58,6 +59,15 @@ if _mcp_lifespan is not None:
 else:
     logger.info("MCP server disabled via RW_MCP_DISABLED")
 
+# ---------------------------------------------------------------------------
+# /run/ concurrency guard — the health tracker state file, combined kubeconfig
+# (~/.kube/gke-kubeconfig), and per-run resources are not designed for
+# overlapping discovery runs. A single non-reentrant module-level lock
+# serialises /run/ so a second request returns 503 immediately instead of
+# racing on shared state.
+# ---------------------------------------------------------------------------
+_run_lock = threading.Lock()
+
 
 @app.get("/info/")
 def info() -> dict[str, Any]:
@@ -77,13 +87,25 @@ def info() -> dict[str, Any]:
 @app.post("/run/")
 async def run(request: Request) -> dict[str, Any]:
     request_data = await request.json()
-    # execute_run is a long-running synchronous call (discovery + rendering
-    # can take minutes). Running it in the event loop would block /health/
-    # and other endpoints, causing the liveness probe to kill the pod.
-    # Delegate to a thread so the event loop stays responsive.
-    import asyncio
-    result = await asyncio.to_thread(execute_run, request_data)
-    return serialize_run_result(result)
+    # Serialise /run/ calls — overlapping discovery/rendering races on the
+    # health tracker state file, combined kubeconfig (~/.kube/), and
+    # per-run resource registry. A second request returns 503.
+    if not _run_lock.acquire(blocking=False):
+        return JSONResponse(
+            status_code=503,
+            content={"detail": "A workspace build is already running; try again later."},
+        )
+    try:
+        # execute_run is a long-running synchronous call (discovery +
+        # rendering can take minutes). Running it in the event loop would
+        # block /health/ and other endpoints, causing the liveness probe
+        # to kill the pod. Delegate to a thread so the event loop stays
+        # responsive.
+        import asyncio
+        result = await asyncio.to_thread(execute_run, request_data)
+        return serialize_run_result(result)
+    finally:
+        _run_lock.release()
 
 
 @app.get("/health/")

--- a/src/workspace_builder/api.py
+++ b/src/workspace_builder/api.py
@@ -77,7 +77,12 @@ def info() -> dict[str, Any]:
 @app.post("/run/")
 async def run(request: Request) -> dict[str, Any]:
     request_data = await request.json()
-    result = execute_run(request_data)
+    # execute_run is a long-running synchronous call (discovery + rendering
+    # can take minutes). Running it in the event loop would block /health/
+    # and other endpoints, causing the liveness probe to kill the pod.
+    # Delegate to a thread so the event loop stays responsive.
+    import asyncio
+    result = await asyncio.to_thread(execute_run, request_data)
     return serialize_run_result(result)
 
 

--- a/src/workspace_builder/health.py
+++ b/src/workspace_builder/health.py
@@ -34,6 +34,7 @@ class RunInfo:
     parsing_errors_count: int = 0
     current_stage: Optional[str] = None
     current_component: Optional[str] = None
+    last_progress_time: Optional[str] = None
     slx_count: Optional[int] = None
     duration_seconds: Optional[float] = None
     

--- a/src/workspace_builder/health.py
+++ b/src/workspace_builder/health.py
@@ -179,11 +179,17 @@ class HealthTracker:
             self._write_state(state)
     
     def update_stage(self, stage: str, component: str = None) -> None:
-        """Update the current stage and component being processed."""
+        """Update the current stage and component being processed.
+
+        Also stamps ``last_progress_time`` so the liveness probe can detect
+        true stuck runs (no stage advancement for a configurable timeout)
+        without killing long but healthy runs.
+        """
         state = self._read_state()
         if state.get('current_run'):
             state['current_run']['current_stage'] = stage
             state['current_run']['current_component'] = component
+            state['current_run']['last_progress_time'] = datetime.now(timezone.utc).isoformat()
             self._write_state(state)
     
     def get_health_info(self) -> HealthInfo:
@@ -211,27 +217,40 @@ class HealthTracker:
         )
     
     def is_healthy(self) -> bool:
-        """Check if the service is healthy for liveness probe."""
+        """Check if the service is healthy for liveness probe.
+
+        The liveness probe must answer the question "is the uvicorn process
+        alive and making progress?" — NOT "has this run finished within an
+        arbitrary time budget?". A long discovery run (multi-cluster, many
+        projects, slow cloud APIs) can legitimately take 30+ minutes, and
+        killing it mid-render loses all work and forces a restart from scratch.
+
+        Stuck-run detection is still valuable, but it's now based on **stage
+        progress staleness** rather than a hard wall-clock cap: if the current
+        stage/component hasn't advanced in a configurable timeout (default
+        1 hour, via ``RW_STUCK_RUN_TIMEOUT_SECONDS``), *then* we consider it
+        stuck. Stage updates happen on every component transition in
+        ``component.py`` → ``update_stage``, so a live run keeps refreshing
+        the staleness clock even though the overall run is long.
+        """
         state = self._read_state()
-        
-        # Service is healthy if:
-        # 1. No current error status
-        # 2. If there's a current run, it's not stuck (< 30 minutes)
-        
+
         if state.get('service_status') == HealthStatus.ERROR.value:
             return False
-        
+
         current_run = state.get('current_run')
         if current_run and current_run.get('start_time'):
-            # Check if run has been going for more than 30 minutes
+            stuck_timeout = int(os.environ.get("RW_STUCK_RUN_TIMEOUT_SECONDS", "3600"))
+            # Use the most recent of: start_time, or last stage update time.
+            progress_time_str = current_run.get('last_progress_time') or current_run.get('start_time')
             try:
-                start_time = datetime.fromisoformat(current_run['start_time'].replace('Z', '+00:00'))
-                elapsed = (datetime.now(timezone.utc) - start_time).total_seconds()
-                if elapsed > 1800:  # 30 minutes
+                progress_time = datetime.fromisoformat(progress_time_str.replace('Z', '+00:00'))
+                elapsed = (datetime.now(timezone.utc) - progress_time).total_seconds()
+                if elapsed > stuck_timeout:
                     return False
             except Exception:
                 pass
-        
+
         return True
     
     def is_ready(self) -> bool:

--- a/src/workspace_builder/test_health.py
+++ b/src/workspace_builder/test_health.py
@@ -14,7 +14,7 @@ from workspace_builder.health import HealthTracker
 
 class HealthTrackerTests(unittest.TestCase):
     def setUp(self):
-        self._tmpdir = tempfile.TemporaryDirectory()
+        self._tmpdir = tempfile.MixedTemporaryDirectory() if hasattr(tempfile, "MixedTemporaryDirectory") else tempfile.TemporaryDirectory()
         self._health_path = os.path.join(self._tmpdir.name, "health_status.json")
         self._env_patch = patch.dict(
             os.environ, {"RW_HEALTH_STATUS_FILE": self._health_path}
@@ -53,6 +53,121 @@ class HealthTrackerTests(unittest.TestCase):
             info = HealthTracker().get_health_info()
 
         self.assertAlmostEqual(7200.0, info.uptime_seconds, places=1)
+
+
+class LivenessProbeTests(unittest.TestCase):
+    """Tests for the liveness probe logic — ensuring long but healthy runs
+    are NOT killed, while truly stuck runs (no stage progress) ARE killed."""
+
+    def setUp(self):
+        self._tmpdir = tempfile.TemporaryDirectory()
+        self._health_path = os.path.join(self._tmpdir.name, "health_status.json")
+        self._env_patches = []
+        self._env_patches.append(patch.dict(os.environ, {
+            "RW_HEALTH_STATUS_FILE": self._health_path,
+            "RW_STUCK_RUN_TIMEOUT_SECONDS": "3600",
+        }))
+        for p in self._env_patches:
+            p.start()
+
+    def tearDown(self):
+        for p in self._env_patches:
+            p.stop()
+        self._tmpdir.cleanup()
+
+    def _write_run_state(self, start_time, last_progress_time=None, status="running"):
+        state = {
+            "service_start_time": datetime(2026, 1, 1, tzinfo=timezone.utc).isoformat(),
+            "service_status": "running",
+            "current_run": {
+                "start_time": start_time.isoformat(),
+                "status": status,
+                "current_stage": "rendering",
+                "last_progress_time": (last_progress_time or start_time).isoformat(),
+            },
+        }
+        with open(self._health_path, "w") as f:
+            json.dump(state, f)
+
+    def test_long_run_with_recent_progress_is_healthy(self):
+        """A run that's been going for 45 minutes but advanced stages 5 minutes
+        ago should be healthy (not killed by the liveness probe)."""
+        now = datetime.now(timezone.utc)
+        start = now - timedelta(minutes=45)
+        last_progress = now - timedelta(minutes=5)
+        self._write_run_state(start, last_progress)
+        tracker = HealthTracker()
+        self.assertTrue(tracker.is_healthy())
+
+    def test_stuck_run_no_progress_for_over_timeout_is_unhealthy(self):
+        """A run that hasn't advanced stages in over the stuck timeout (1h)
+        should be unhealthy."""
+        now = datetime.now(timezone.utc)
+        start = now - timedelta(hours=2)
+        last_progress = now - timedelta(hours=1, minutes=5)
+        self._write_run_state(start, last_progress)
+        tracker = HealthTracker()
+        self.assertFalse(tracker.is_healthy())
+
+    def test_error_status_is_unhealthy(self):
+        now = datetime.now(timezone.utc)
+        state = {
+            "service_start_time": datetime(2026, 1, 1, tzinfo=timezone.utc).isoformat(),
+            "service_status": "error",
+            "current_run": None,
+        }
+        with open(self._health_path, "w") as f:
+            json.dump(state, f)
+        tracker = HealthTracker()
+        self.assertFalse(tracker.is_healthy())
+
+    def test_no_current_run_is_healthy(self):
+        state = {
+            "service_start_time": datetime(2026, 1, 1, tzinfo=timezone.utc).isoformat(),
+            "service_status": "healthy",
+            "current_run": None,
+        }
+        with open(self._health_path, "w") as f:
+            json.dump(state, f)
+        tracker = HealthTracker()
+        self.assertTrue(tracker.is_healthy())
+
+    def test_long_run_without_last_progress_uses_start_time(self):
+        """If last_progress_time is missing (older runs), fall back to
+        start_time for staleness, but the new 1h default timeout is more
+        lenient than the old 30 min hard cap."""
+        now = datetime.now(timezone.utc)
+        start = now - timedelta(minutes=45)
+        state = {
+            "service_start_time": datetime(2026, 1, 1, tzinfo=timezone.utc).isoformat(),
+            "service_status": "running",
+            "current_run": {
+                "start_time": start.isoformat(),
+                "status": "running",
+            },
+        }
+        with open(self._health_path, "w") as f:
+            json.dump(state, f)
+        tracker = HealthTracker()
+        # 45 min < 1h timeout → healthy
+        self.assertTrue(tracker.is_healthy())
+
+    def test_update_stage_stamps_progress_time(self):
+        """update_stage must write last_progress_time so the liveness probe
+        can track real progress, not just run start time."""
+        tracker = HealthTracker()
+        tracker.start_run([])
+
+        before = datetime.now(timezone.utc)
+        tracker.update_stage("rendering", "render_output_items")
+        after = datetime.now(timezone.utc)
+
+        with open(self._health_path) as f:
+            state = json.load(f)
+        progress_str = state["current_run"]["last_progress_time"]
+        progress_time = datetime.fromisoformat(progress_str.replace("Z", "+00:00"))
+        self.assertGreaterEqual(progress_time, before - timedelta(seconds=1))
+        self.assertLessEqual(progress_time, after + timedelta(seconds=1))
 
 
 if __name__ == "__main__":  # pragma: no cover


### PR DESCRIPTION
Update GKE authentication templates to support more flexible location resolution (using `location` before `zone` or `region`) and include support for `gcp_service_account_file` auth type. Added new tests for GKE auth templates.

Also updated documentation for indexed resources and generation rules to improve clarity and link structure.

- feat(templates): improve GKE auth template logic and location handling
- docs: update resource catalog documentation and links
- test: add GKE auth template tests
- chore: bump version to 0.11.4

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes affect kubeconfig generation, Kubernetes auth workspaceKeys, and liveness/concurrency for long runs; behavior is heavily unit-tested but misconfiguration could still break multi-project GKE access or concurrent `/run/` expectations.
> 
> **Overview**
> **Release 0.11.4** bundles GKE discovery/auth fixes, workspace-builder reliability improvements, and small doc updates.
> 
> **GKE discovery and kubeconfig** (`gcp_utils.py`): Auto-discovery now calls `list_clusters` per configured project (via `_normalize_project_ids` and priority: `discoveryConfig.projectId` → `gcp.projects` → `projectId`). Discovered clusters get `projectId`; dedup uses `(name, projectId)`. Same cluster name in different projects gets disambiguated kubeconfig context names (`proj-a--prod-cluster`) while the Container API still uses the real name; `namespaceLODs` / `defaultNamespaceLOD` flow into the workspace-builder extension for disambiguated contexts.
> 
> **Auth templates**: `kubernetes-auth.yaml` gains GKE branches so discovered GKE clusters emit `gcp:adc@kubeconfig` / `gcp:sa@kubeconfig` instead of the generic kubeconfig secret fallback. Both GKE templates use `cluster.location` (with zone/region fallback) and support `gcp_service_account_file`.
> 
> **Service behavior**: `/run/` is serialized (503 if a build is in flight), runs in a thread pool so `/health/` stays responsive, liveness uses **stage progress staleness** (`last_progress_time`, default 1h via `RW_STUCK_RUN_TIMEOUT_SECONDS`) instead of a 30-minute run cap, and rendering reports progress to the health tracker. Default Jinja environments are cached in `template.py` for large renders.
> 
> **Docs**: Indexed-resource README clarifies catalog purpose and links full catalogs on GitHub; generation-rules “see also” trimmed.
> 
> **Tests**: New coverage for GKE auth templates, multi-project discovery, collisions/LOD, and liveness logic.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c387294343b8b1792496984a5e44bff1c817cce9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->