### PR TITLE
chore: bump version to 0.11.5

### DIFF
--- a/docs/authoring/indexed-resources/aws-resource-catalog.md
+++ b/docs/authoring/indexed-resources/aws-resource-catalog.md
@@ -2,7 +2,7 @@
 
 Resource types the native `awsapi` indexer can discover. Use the canonical CloudQuery table name (or any listed alias) as the `resourceTypes` value in a generation rule. This page is the companion catalog for [`aws.md`](./aws.md); see that page for how to enable the indexer and what data each row carries.
 
-_1119 resource types - 3 typed (rich-payload), 1116 generic (Cloud Control envelope). Generated 2026-07-09 from `src/indexers/aws_resource_type_registry.yaml`._
+_1119 resource types - 3 typed (rich-payload), 1116 generic (Cloud Control envelope). Generated 2026-07-15 from `src/indexers/aws_resource_type_registry.yaml`._
 
 _Regenerate with `python scripts/aws/dump_aws_resource_catalog.py` after touching the registry or overrides; do not hand-edit this file._
 

--- a/docs/authoring/indexed-resources/azure-resource-catalog.md
+++ b/docs/authoring/indexed-resources/azure-resource-catalog.md
@@ -2,7 +2,7 @@
 
 Resource types the native `azureapi` indexer can discover. Use the canonical CloudQuery table name (or any listed alias) as the `resourceTypes` value in a generation rule. This page is the companion catalog for [`azure.md`](./azure.md); see that page for how to enable the indexer and what data each row carries.
 
-_619 resource types - 25 typed (rich-payload), 594 generic (basic envelope). Generated 2026-07-09 from `src/indexers/azure_resource_type_registry.yaml`._
+_619 resource types - 25 typed (rich-payload), 594 generic (basic envelope). Generated 2026-07-15 from `src/indexers/azure_resource_type_registry.yaml`._
 
 _Regenerate with `python scripts/azure/dump_azure_resource_catalog.py` after touching the registry or overrides; do not hand-edit this file._
 

--- a/docs/authoring/indexed-resources/gcp-resource-catalog.md
+++ b/docs/authoring/indexed-resources/gcp-resource-catalog.md
@@ -2,7 +2,7 @@
 
 Resource types the native `gcpapi` indexer can discover. Use the canonical CloudQuery table name (or any listed alias) as the `resourceTypes` value in a generation rule. This page is the companion catalog for [`gcp.md`](./gcp.md); see that page for how to enable the indexer and what data each row carries.
 
-_404 resource types - 13 typed (SDK collectors), 391 generic (Cloud Asset Inventory pass). Generated 2026-07-09 from `src/indexers/gcp_resource_type_registry.yaml`._
+_404 resource types - 13 typed (SDK collectors), 391 generic (Cloud Asset Inventory pass). Generated 2026-07-15 from `src/indexers/gcp_resource_type_registry.yaml`._
 
 _Regenerate with `python scripts/gcp/dump_gcp_resource_catalog.py` after touching the registry or overrides; do not hand-edit this file._
 

--- a/docs/authoring/indexed-resources/kubernetes-resource-catalog.md
+++ b/docs/authoring/indexed-resources/kubernetes-resource-catalog.md
@@ -2,7 +2,7 @@
 
 Built-in Kubernetes resource types the kubeapi indexer discovers.
 
-_Generated 2026-07-09 from `indexers/kubetypes.py`._
+_Generated 2026-07-15 from `indexers/kubetypes.py`._
 
 Custom CRDs are declared in generation rules (`resourceTypes`) and indexed
 selectively — they are not listed here.

--- a/docs/authoring/indexed-resources/runwhen-platform-resource-catalog.md
+++ b/docs/authoring/indexed-resources/runwhen-platform-resource-catalog.md
@@ -2,7 +2,7 @@
 
 Resource types indexed under `platform: runwhen`.
 
-_Generated 2026-07-09 from `scripts/runwhen/dump_runwhen_resource_catalog.py`._
+_Generated 2026-07-15 from `scripts/runwhen/dump_runwhen_resource_catalog.py`._
 
 | Resource type | Match names | Typed collector | Notes |
 |---|---|---|---|

--- a/docs/user-guide/cloud-discovery/kubernetes.md
+++ b/docs/user-guide/cloud-discovery/kubernetes.md
@@ -12,7 +12,37 @@ The "namespaceLODs" field is a dictionary/object where the key/field is the name
 
 The "namespaces" field should only be needed in cases of limited privilege where the credentials in the kubeconfig file don't have privileges to list all the available namespaces, but do have privileges to access resources in certain namespaces, but you need to already know the names of the namespaces. So this is a mechanism for specifying this explicit list of namespaces.
 
+#### OpenShift / restricted RBAC: grant `namespaces` get
 
+On OpenShift (and other restricted clusters) it is common to:
+
+- Disable cluster-wide `view` for the workspace-builder ServiceAccount
+- Bind a namespaced Role that can list Deployments, Services, etc. in selected projects
+- Use `cloudConfig.kubernetes.namespaces` (or fall back to OpenShift `projects`) to name those projects
+
+That lets discovery **enter** the namespaces and scan in-namespace resources. It does **not** replace permission to **`GET` the cluster-scoped `Namespace` API object**.
+
+Without `get`/`list` on `namespaces` (via a **ClusterRole** — a namespaced Role cannot grant this):
+
+- Discovery may continue with a synthesized stub Namespace (name only)
+- CodeCollection templates that expect a real Namespace (e.g. `resource.metadata`, LOD annotations) fail at render time, for example:
+
+```text
+Error processing template content: template_file_name=k8s-namespace-healthcheck-slx.yaml;
+underlying_error='dict object' has no attribute 'metadata'; error_type=UndefinedError
+```
+
+The same failure mode shows up for other namespace-rooted SLXs (`k8s-pod-resources-slx.yaml`, `k8s-serviceaccount-check-slx.yaml`, …), with runbook/sli artifacts skipped because `slx.yaml` did not render.
+
+**Recommended:** keep the namespaced Roles for workload discovery, and separately grant the SA:
+
+```yaml
+apiGroups: [""]
+resources: ["namespaces"]
+verbs: ["get", "list"]
+```
+
+as a ClusterRole + ClusterRoleBinding (or use cluster `view` if that is acceptable for the environment).
 
 ### Discovery Exclusions
 

--- a/src/VERSION
+++ b/src/VERSION
@@ -1,4 +1,4 @@
 {
   "name": "runwhen-local",
-  "version": "0.11.4"
+  "version": "0.11.5"
 }

--- a/src/indexers/kubeapi.py
+++ b/src/indexers/kubeapi.py
@@ -817,6 +817,13 @@ def index(component_context: Context):
                             # I doubt will be an issue for the foreseeable future (famous last words).
                             # And also, that's an issue with the current format of the namespace
                             # LODs dict too, i.e. the key names are not scoped to a specific cluster.
+                            namespace_names.update(custom_namespace_names or [])
+
+                        # Always union configured explicit namespaces. list_namespace (and
+                        # OpenShift projects) may return a *partial* set the SA can see;
+                        # cloudConfig.kubernetes.namespaces must still be interrogated on
+                        # OpenShift installs that cannot list all namespaces.
+                        if custom_namespace_names:
                             namespace_names.update(custom_namespace_names)
 
                         if len(namespace_names) == 0:
@@ -953,66 +960,93 @@ def index(component_context: Context):
                             logger.info(f"Cluster: {cluster_name}, Namespace: {namespace_name}, LOD: {namespace_lod}")
 
                             try:
-                                # Fetch namespace details from the K8s API
+                                # Prefer live Namespace object (annotations drive LOD overrides /
+                                # include-exclude filters). On OpenShift this often 403s because
+                                # Namespace is cluster-scoped and RoleBindings cannot grant it —
+                                # that is expected. Fall through to a stub so explicitly listed
+                                # (or project-discovered) namespaces still get namespaced
+                                # Deployments/Services/... interrogated below.
                                 raw_resource = core_api_client.read_namespace(namespace_name)
+                                namespace_from_api = True
+                            except ApiException as e:
+                                logger.info(
+                                    f"Cannot read Namespace object '{namespace_name}' in cluster "
+                                    f"'{cluster_name}' (status={e.status}); synthesizing stub and "
+                                    f"continuing with namespaced resource scan. Error: {e}"
+                                )
+                                raw_resource = None
+                                namespace_from_api = False
 
+                            if namespace_from_api:
                                 # **Always fetch annotations first**
                                 annotation_lod = get_lod_from_annotations(raw_resource, lod_annotations)
                                 if annotation_lod is not None:
                                     logger.info(f"Overriding LOD for namespace '{namespace_name}' based on annotation: {annotation_lod}")
                                     namespace_lod = annotation_lod  # **Annotations override any config-based LOD**
 
-                                # **Final Fallback** (if no valid LOD is set, use BASIC)
-                                if namespace_lod is None:
-                                    namespace_lod = LevelOfDetail.BASIC
+                            # **Final Fallback** (if no valid LOD is set, use BASIC)
+                            if namespace_lod is None:
+                                namespace_lod = LevelOfDetail.BASIC
 
-                                logger.info(f"Final LOD for namespace '{namespace_name}': {namespace_lod}")
+                            logger.info(f"Final LOD for namespace '{namespace_name}': {namespace_lod}")
 
-                                if namespace_lod == LevelOfDetail.NONE:
-                                    continue  # Skip namespace if LOD is set to NONE
+                            if namespace_lod == LevelOfDetail.NONE:
+                                continue  # Skip namespace if LOD is set to NONE
 
+                            if namespace_from_api:
                                 if (include_annotations or include_labels) and not has_included_annotations_or_labels(raw_resource, include_annotations, include_labels):
                                     continue  # Skip this resource if it doesn't meet inclusion criteria
 
                                 if has_excluded_annotations_or_labels(raw_resource, exclude_annotations, exclude_labels):
                                     continue
-                                                 
+
                                 # Extract owner metadata if available
                                 owner_name = extract_owner_name(raw_resource)
                                 namespace_attributes = kubeapi_parsers.parse_namespace(raw_resource)
-                                namespace_attributes['cluster'] = cluster
-                                namespace_attributes['lod'] = namespace_lod
-                                if owner_name:
-                                    namespace_attributes['owner'] = owner_name
+                            else:
+                                # Stub Namespace for OpenShift / restricted-RBAC: we know the
+                                # name from config (or projects), but cannot GET the cluster-
+                                # scoped Namespace object. Downstream list_namespaced_* calls
+                                # are the real accessibility check.
+                                owner_name = None
+                                namespace_attributes = {
+                                    'name': namespace_name,
+                                    'uid': None,
+                                    'kind': 'Namespace',
+                                    'labels': {},
+                                    'annotations': {},
+                                    'resource': {},
+                                }
 
-                                # Check if namespace already exists in registry (from another context)
-                                existing_namespace = registry.lookup_resource(
-                                    KUBERNETES_PLATFORM,
-                                    KubernetesResourceType.NAMESPACE.value,
-                                    namespace_qualified_name
-                                )
-                                
-                                if existing_namespace:
-                                    logger.info(f"Namespace '{namespace_qualified_name}' already exists in registry from previous context. "
-                                               f"Current context '{context_name}' will update LOD to '{namespace_lod}' and process resources.")
-                                else:
-                                    logger.info(f"Adding new namespace '{namespace_qualified_name}' to registry from context '{context_name}' with LOD '{namespace_lod}'")
-                                
-                                namespace = registry.add_resource(
-                                    KUBERNETES_PLATFORM,
-                                    KubernetesResourceType.NAMESPACE.value,
-                                    namespace_name,
-                                    namespace_qualified_name,
-                                    namespace_attributes
-                                )
+                            namespace_attributes['cluster'] = cluster
+                            namespace_attributes['lod'] = namespace_lod
+                            if owner_name:
+                                namespace_attributes['owner'] = owner_name
 
-                                cluster_namespaces[namespace_qualified_name] = namespace
-                                namespaces[namespace_qualified_name] = namespace
-                                logger.debug(f"Added namespace '{namespace_qualified_name}' to local namespaces dict for resource processing in context '{context_name}'")
+                            # Check if namespace already exists in registry (from another context)
+                            existing_namespace = registry.lookup_resource(
+                                KUBERNETES_PLATFORM,
+                                KubernetesResourceType.NAMESPACE.value,
+                                namespace_qualified_name
+                            )
 
-                            except ApiException as e:
-                                logger.info(f"Error accessing namespace '{namespace_name}' in cluster '{cluster_name}'; skipping. Error: {e}")
-                                pass
+                            if existing_namespace:
+                                logger.info(f"Namespace '{namespace_qualified_name}' already exists in registry from previous context. "
+                                           f"Current context '{context_name}' will update LOD to '{namespace_lod}' and process resources.")
+                            else:
+                                logger.info(f"Adding new namespace '{namespace_qualified_name}' to registry from context '{context_name}' with LOD '{namespace_lod}'")
+
+                            namespace = registry.add_resource(
+                                KUBERNETES_PLATFORM,
+                                KubernetesResourceType.NAMESPACE.value,
+                                namespace_name,
+                                namespace_qualified_name,
+                                namespace_attributes
+                            )
+
+                            cluster_namespaces[namespace_qualified_name] = namespace
+                            namespaces[namespace_qualified_name] = namespace
+                            logger.debug(f"Added namespace '{namespace_qualified_name}' to local namespaces dict for resource processing in context '{context_name}'")
                         logger.info(f"Context '{context_name}' will process {len(namespaces)} namespace(s) for resources: {list(namespaces.keys())}")
                         for namespace in namespaces.values():
                             namespace_qualified_name = namespace.qualified_name

--- a/src/workspace_builder/access_log_filters.py
+++ b/src/workspace_builder/access_log_filters.py
@@ -1,0 +1,25 @@
+"""Uvicorn access-log filters for the workspace-builder REST service."""
+
+from __future__ import annotations
+
+import logging
+
+# Paths that kubectl/OpenShift probes hit continuously. Access logs for these
+# drown useful discovery output, so they are dropped on ``uvicorn.access``.
+PROBE_ACCESS_PATH_MARKERS = (
+    "/health/",
+    "/healthz",
+    "/livez",
+    "/readyz",
+)
+
+
+class ProbeAccessLogFilter(logging.Filter):
+    """Drop uvicorn access-log lines for probe endpoints."""
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        try:
+            message = record.getMessage()
+        except Exception:
+            return True
+        return not any(marker in message for marker in PROBE_ACCESS_PATH_MARKERS)

--- a/src/workspace_builder/startup.py
+++ b/src/workspace_builder/startup.py
@@ -9,6 +9,7 @@ import sys
 
 from component import init_components
 from enrichers.code_collection import init_code_collections
+from .access_log_filters import ProbeAccessLogFilter
 
 _BOOTSTRAPPED = False
 
@@ -45,6 +46,11 @@ def configure_logging() -> None:
             },
         }
     )
+    # Uvicorn attaches its own access handler after import; filtering the logger
+    # (not a specific handler) applies regardless of how uvicorn configures it.
+    access_logger = logging.getLogger("uvicorn.access")
+    if not any(isinstance(f, ProbeAccessLogFilter) for f in access_logger.filters):
+        access_logger.addFilter(ProbeAccessLogFilter())
 
 
 def bootstrap() -> None:

--- a/src/workspace_builder/test_health.py
+++ b/src/workspace_builder/test_health.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import logging
 import os
 import tempfile
 import unittest
@@ -168,6 +169,33 @@ class LivenessProbeTests(unittest.TestCase):
         progress_time = datetime.fromisoformat(progress_str.replace("Z", "+00:00"))
         self.assertGreaterEqual(progress_time, before - timedelta(seconds=1))
         self.assertLessEqual(progress_time, after + timedelta(seconds=1))
+
+
+class ProbeAccessLogFilterTests(unittest.TestCase):
+    def test_drops_health_probe_access_lines(self):
+        from workspace_builder.access_log_filters import ProbeAccessLogFilter
+
+        filt = ProbeAccessLogFilter()
+        health = logging.LogRecord(
+            name="uvicorn.access",
+            level=logging.INFO,
+            pathname=__file__,
+            lineno=1,
+            msg='10.128.0.2:55136 - "GET /health/ HTTP/1.1" 200 OK',
+            args=(),
+            exc_info=None,
+        )
+        other = logging.LogRecord(
+            name="uvicorn.access",
+            level=logging.INFO,
+            pathname=__file__,
+            lineno=1,
+            msg='10.128.0.2:12345 - "GET /info/ HTTP/1.1" 200 OK',
+            args=(),
+            exc_info=None,
+        )
+        self.assertFalse(filt.filter(health))
+        self.assertTrue(filt.filter(other))
 
 
 if __name__ == "__main__":  # pragma: no cover


### PR DESCRIPTION
Update the version in the VERSION file to 0.11.5. This change reflects the latest enhancements and fixes made in the codebase.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core Kubernetes indexing behavior (namespace set and stub resources), which can alter discovered resources and template inputs; logging filter is low risk.
> 
> **Overview**
> **Release 0.11.5** bumps `src/VERSION` and refreshes generated catalog doc timestamps only (no registry content changes).
> 
> **Kubernetes discovery (`kubeapi`)** now keeps **explicit `cloudConfig.kubernetes.namespaces`** in the scan set even when cluster listing returns a partial set (typical on OpenShift). When **`read_namespace` fails** (e.g. no cluster-scoped `namespaces` permission), discovery **logs and continues** with a **stub Namespace** (name-only attributes) so in-namespace workloads still index; live Namespace objects still drive LOD annotations and include/exclude filters when accessible.
> 
> **Ops noise:** **`ProbeAccessLogFilter`** on `uvicorn.access` drops access lines for `/health/`, `/healthz`, `/livez`, and `/readyz`; wired in `startup.configure_logging` with a unit test.
> 
> **Docs:** `docs/user-guide/cloud-discovery/kubernetes.md` adds OpenShift/restricted-RBAC guidance (namespaced Roles vs **`namespaces` get/list** ClusterRole) and template failure modes when Namespace metadata is missing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1e2fbb16cb6627ba3cfd772ab30b0b9fecb3adef. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->