### PR TITLE
feat: codeCollection auth from K8s secrets/env vars, repoPath for workspace-scoped codebundles, podman support in test taskfile

### DIFF
--- a/.test/k8s/basic/Taskfile.yaml
+++ b/.test/k8s/basic/Taskfile.yaml
@@ -1,5 +1,8 @@
 version: "3"
 
+vars:
+  CONTAINER_ENGINE: '{{.CONTAINER_ENGINE | default "docker"}}'
+
 tasks:
   default:
     desc: "Generate workspaceInfo and rebuild/test"
@@ -75,12 +78,13 @@ tasks:
       - |
         BUILD_DIR=../../../src/
         CONTAINER_NAME="RunWhenLocal"
-        if docker ps -q --filter "name=$CONTAINER_NAME" | grep -q .; then
+        CE="{{.CONTAINER_ENGINE}}"
+        if $CE ps -q --filter "name=$CONTAINER_NAME" | grep -q .; then
           echo "Stopping and removing existing container $CONTAINER_NAME..."
-          docker stop $CONTAINER_NAME && docker rm $CONTAINER_NAME
-        elif docker ps -a -q --filter "name=$CONTAINER_NAME" | grep -q .; then
+          $CE stop $CONTAINER_NAME && $CE rm $CONTAINER_NAME
+        elif $CE ps -a -q --filter "name=$CONTAINER_NAME" | grep -q .; then
           echo "Removing existing stopped container $CONTAINER_NAME..."
-          docker rm $CONTAINER_NAME
+          $CE rm $CONTAINER_NAME
         else
           echo "No existing container named $CONTAINER_NAME found."
         fi
@@ -89,10 +93,18 @@ tasks:
         rm -rf output || { echo "Failed to remove output directory"; exit 1; }
         mkdir output && chmod 777 output || { echo "Failed to set permissions"; exit 1; }
         ## Building Container Image
-        docker buildx build --builder mybuilder --platform linux/amd64  --build-arg INCLUDE_CODE_COLLECTION_CACHE=true -t runwhen-local:test -f $BUILD_DIR/Dockerfile $BUILD_DIR --load
+        if [[ "$CE" == *podman* ]]; then
+          $CE build --platform linux/amd64 --build-arg INCLUDE_CODE_COLLECTION_CACHE=true -t runwhen-local:test -f $BUILD_DIR/Dockerfile $BUILD_DIR
+        else
+          $CE buildx build --builder mybuilder --platform linux/amd64 --build-arg INCLUDE_CODE_COLLECTION_CACHE=true -t runwhen-local:test -f $BUILD_DIR/Dockerfile $BUILD_DIR --load
+        fi
 
         ## Use this if you need to test both arm64/amd64 builds
-        # docker buildx build --builder mybuilder --platform linux/amd64,linux/arm64  -t runwhen-local:test -f $BUILD_DIR/Dockerfile $BUILD_DIR
+        # if [[ "$CE" == *podman* ]]; then
+        #   $CE build --platform linux/amd64,linux/arm64 --build-arg INCLUDE_CODE_COLLECTION_CACHE=true -t runwhen-local:test -f $BUILD_DIR/Dockerfile $BUILD_DIR
+        # else
+        #   $CE buildx build --builder mybuilder --platform linux/amd64,linux/arm64 -t runwhen-local:test -f $BUILD_DIR/Dockerfile $BUILD_DIR
+        # fi
 
     silent: true
 
@@ -135,8 +147,8 @@ tasks:
         _rwl_wait_for_rest "$CONTAINER_NAME"
         _rwl_run_discovery "$CONTAINER_NAME" "{{.CLI_ARGS}}"
         _rwl_write_slx_count
-        docker stop "$CONTAINER_NAME" 2>/dev/null || true
-        docker rm "$CONTAINER_NAME" 2>/dev/null || true
+        {{.CONTAINER_ENGINE}} stop "$CONTAINER_NAME" 2>/dev/null || true
+        {{.CONTAINER_ENGINE}} rm "$CONTAINER_NAME" 2>/dev/null || true
     silent: true
 
 
@@ -154,8 +166,8 @@ tasks:
         _rwl_wait_for_rest "$CONTAINER_NAME"
         _rwl_run_discovery "$CONTAINER_NAME" "{{.CLI_ARGS}}"
         _rwl_write_slx_count
-        docker stop "$CONTAINER_NAME" 2>/dev/null || true
-        docker rm "$CONTAINER_NAME" 2>/dev/null || true
+        {{.CONTAINER_ENGINE}} stop "$CONTAINER_NAME" 2>/dev/null || true
+        {{.CONTAINER_ENGINE}} rm "$CONTAINER_NAME" 2>/dev/null || true
     silent: true
 
   ci-test-1:
@@ -538,7 +550,7 @@ tasks:
     desc: "Check and clean up RunWhen Local discovery output"
     cmds:
       - |
-        docker rm -f RunWhenLocal 2>/dev/null || true
+        {{.CONTAINER_ENGINE}} rm -f RunWhenLocal 2>/dev/null || true
         rm -rf output
         rm -f workspaceInfo.yaml run_sh_output.log container_logs.log slx_count.txt
     silent: true

--- a/.test/k8s/basic/_discovery_common.sh
+++ b/.test/k8s/basic/_discovery_common.sh
@@ -1,13 +1,18 @@
 #!/usr/bin/env bash
 # Shared discovery helpers for .test/k8s/basic Taskfile tasks.
 # Sourced by run-rwl-discovery / ci-run-rwl-discovery variants.
+#
+# Use CONTAINER_ENGINE env var to override the container engine (docker/podman).
 
 set -euo pipefail
+
+# Fall back to docker if CONTAINER_ENGINE is not set.
+readonly CONTAINER_ENGINE="${CONTAINER_ENGINE:-docker}"
 
 _rwl_prepare_container() {
   local container_name="${1:-RunWhenLocal}"
   rm -f run_sh_output.log container_logs.log slx_count.txt || true
-  docker rm -f "$container_name" 2>/dev/null || true
+  $CONTAINER_ENGINE rm -f "$container_name" 2>/dev/null || true
   echo "Cleaning up output directory..."
   rm -rf output || { echo "Failed to remove output directory"; exit 1; }
   mkdir output && chmod 777 output || { echo "Failed to set permissions"; exit 1; }
@@ -16,9 +21,9 @@ _rwl_prepare_container() {
 _rwl_start_container() {
   local container_name="$1"
   shift
-  # Extra docker run args (e.g. --add-host github.com:0.0.0.0) follow $container_name.
+  # Extra container run args (e.g. --add-host github.com:0.0.0.0) follow $container_name.
   echo "Starting new container $container_name..."
-  docker run -d \
+  $CONTAINER_ENGINE run -d \
     -e DEBUG_LOGGING="${DEBUG_LOGGING:-false}" \
     -e WB_WRITE_WORKSPACE_FILES_TO_DISK=true \
     --name "$container_name" \
@@ -34,12 +39,12 @@ _rwl_wait_for_rest() {
   local rest_ready=0
   local i
   for i in $(seq 1 30); do
-    if ! docker ps -q --filter "name=$container_name" | grep -q .; then
+    if ! $CONTAINER_ENGINE ps -q --filter "name=$container_name" | grep -q .; then
       echo "Container $container_name exited during startup. Logs:"
-      docker logs "$container_name" 2>&1 | tee container_logs.log
+      $CONTAINER_ENGINE logs "$container_name" 2>&1 | tee container_logs.log
       exit 1
     fi
-    if docker exec "$container_name" curl -sf http://localhost:8000/info/ >/dev/null 2>&1; then
+    if $CONTAINER_ENGINE exec "$container_name" curl -sf http://localhost:8000/info/ >/dev/null 2>&1; then
       rest_ready=1
       break
     fi
@@ -47,7 +52,7 @@ _rwl_wait_for_rest() {
   done
   if [ "$rest_ready" -ne 1 ]; then
     echo "REST service never became ready. Container logs:"
-    docker logs "$container_name" 2>&1 | tee container_logs.log
+    $CONTAINER_ENGINE logs "$container_name" 2>&1 | tee container_logs.log
     exit 1
   fi
 }
@@ -58,13 +63,13 @@ _rwl_run_discovery() {
   echo "Running workspace builder script in container..."
   set -o pipefail
   # shellcheck disable=SC2086
-  docker exec -w /workspace-builder "$container_name" ./run.sh $extra_args --verbose 2>&1 | tee run_sh_output.log || {
+  $CONTAINER_ENGINE exec -w /workspace-builder "$container_name" ./run.sh $extra_args --verbose 2>&1 | tee run_sh_output.log || {
     echo "Error executing script in container. Container logs:"
-    docker logs "$container_name" 2>&1 | tee container_logs.log
+    $CONTAINER_ENGINE logs "$container_name" 2>&1 | tee container_logs.log
     exit 1
   }
   set +o pipefail
-  docker logs "$container_name" > container_logs.log 2>&1 || true
+  $CONTAINER_ENGINE logs "$container_name" > container_logs.log 2>&1 || true
 }
 
 _rwl_count_slxs() {

--- a/docs/user-guide/configuration/codecollection.md
+++ b/docs/user-guide/configuration/codecollection.md
@@ -33,20 +33,73 @@ For the string specification the string is just the URL of the git repo. The str
 
 The object block format for a code collection entry is an object/dictionary with the following fields:
 
-| Field Name  | Description                                                           |
-| ----------- | --------------------------------------------------------------------- |
-| repoURL     | URL of the git repo for the code collection                           |
-| branch      | branch to use in the repo                                             |
-| tag         | tag to use in the repo                                                |
-| ref         | git ref to use in the repo                                            |
-| authUser    | user id to use when cloning the repo                                  |
-| authToken   | auth token credential to use when cloning repo                        |
-| action      | inclusion action, either "include" or "exclude", defaults to "include |
-| codeBundles | List of code bundles to enable for the code collection                |
+| Field Name           | Description                                                           |
+| -------------------- | --------------------------------------------------------------------- |
+| repoURL              | URL of the git repo for the code collection                           |
+| branch               | branch to use in the repo                                             |
+| tag                  | tag to use in the repo                                                |
+| ref                  | git ref to use in the repo                                            |
+| authUser             | user id to use when cloning the repo                                  |
+| authToken            | auth token credential to use when cloning repo                        |
+| authTokenSecretName  | Name of a Kubernetes Secret in the workspace-builder namespace containing the auth token |
+| authTokenSecretKey   | Key within the Kubernetes Secret holding the token (default: "token") |
+| authTokenFromEnv     | Environment variable name whose value contains the auth token         |
+| action               | inclusion action, either "include" or "exclude", defaults to "include |
+| codeBundles          | List of code bundles to enable for the code collection                |
 
 Only one of the branch, tag or ref fields should be specified.
 
-The authUser and authToken fields are only necessary for non-public repos. All the RunWhen-provided code collections are open source, so they don't require any credentials.
+The authentication fields are only necessary for non-public repos. All the RunWhen-provided code collections are open source, so they don't require any credentials.
+
+**Authentication priority** (checked in order):
+1. `authTokenSecretName` + `authTokenSecretKey` — reads from a Kubernetes Secret in the workspace-builder namespace. The secret must exist in the same namespace as the workspace builder pod.
+2. `authTokenFromEnv` — reads from the named environment variable.
+3. `authToken` — inline token value (least preferred; embeds the token in workspaceInfo).
+
+**Recommended: Kubernetes Secret** (does not embed the token in workspaceInfo):
+
+```yaml
+codeCollections:
+- repoURL: https://github.com/author-account/my-private-code-collection.git
+  authTokenSecretName: git-token
+  authTokenSecretKey: token
+  codeBundles:
+  - my-code-bundle
+```
+
+The referenced Kubernetes Secret should be created in the workspace-builder namespace:
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: git-token
+  namespace: runwhen-local
+type: Opaque
+data:
+  token: <base64-encoded-git-token>
+```
+
+**Alternative: Environment variable:**
+
+```yaml
+codeCollections:
+- repoURL: https://github.com/author-account/my-private-code-collection.git
+  authTokenFromEnv: GIT_AUTH_TOKEN
+  codeBundles:
+  - my-code-bundle
+```
+
+**Inline token** (not recommended for production):
+
+```yaml
+codeCollections:
+- repoURL: https://github.com/author-account/my-private-code-collection.git
+  authUser: my-user
+  authToken: ghp_abc123...
+  codeBundles:
+  - my-code-bundle
+```
 
 The "action" field lets you toggle between inclusion/whitelist and exclusion/blacklist. The most common use case will just be an explicit whitelist of included code collections. Since the "action" field defaults to "include" you can just omit it for that use case.
 
@@ -57,6 +110,28 @@ The custom code collection configuration is useful for code collection authors. 
 ```yaml
 codeCollections:
 - repoURL: https://github.com/author-account/my-custom-code-collection.git
+  codeBundles:
+  - my-code-bundle
+```
+
+For private repositories, use `authTokenSecretName` (recommended) to reference a Kubernetes Secret instead of embedding the token in workspaceInfo:
+
+```yaml
+codeCollections:
+- repoURL: https://github.com/author-account/my-private-code-collection.git
+  authTokenSecretName: git-token
+  authTokenSecretKey: token
+  codeBundles:
+  - my-code-bundle
+```
+
+If your git provider uses a username+token scheme, set `authUser` alongside `authTokenSecretName`:
+
+```yaml
+codeCollections:
+- repoURL: https://github.com/author-account/my-private-code-collection.git
+  authUser: my-user
+  authTokenSecretName: git-token
   codeBundles:
   - my-code-bundle
 ```

--- a/docs/user-guide/configuration/codecollection.md
+++ b/docs/user-guide/configuration/codecollection.md
@@ -46,6 +46,38 @@ The object block format for a code collection entry is an object/dictionary with
 | authTokenFromEnv     | Environment variable name whose value contains the auth token         |
 | action               | inclusion action, either "include" or "exclude", defaults to "include |
 | codeBundles          | List of code bundles to enable for the code collection                |
+| repoPath             | Subdirectory path within the repo where `codebundles/` lives (default: repo root). Use this to store codebundles for multiple workspaces in a single repo. |
+
+**`repoPath` — Workspace-scoped codebundles:**
+
+By default, the workspace builder expects a `codebundles/` directory at the repo root. Use `repoPath` to point to codebundles nested under an arbitrary path. This enables a single git repository to host codebundles for multiple workspaces:
+
+```
+<repo_root>/
+  zzz_generated/
+    my-workspace/
+      codebundles/
+        my-code-bundle/
+          .runwhen/
+            generation-rules/
+              generation-rule.yaml
+            templates/
+              ...
+  another-workspace/
+    codebundles/
+      ...
+```
+
+```yaml
+codeCollections:
+- repoURL: https://git.example.com/org/custom-code-collections.git
+  ref: master
+  repoPath: zzz_generated/my-workspace
+  codeBundles:
+  - my-code-bundle
+```
+
+When `repoPath` is omitted or empty (the default), codebundles are expected at the repo root (existing behavior).
 
 Only one of the branch, tag or ref fields should be specified.
 

--- a/src/VERSION
+++ b/src/VERSION
@@ -1,4 +1,4 @@
 {
   "name": "runwhen-local",
-  "version": "0.11.5"
+  "version": "0.11.6"
 }

--- a/src/enrichers/code_collection.py
+++ b/src/enrichers/code_collection.py
@@ -1,3 +1,4 @@
+import base64
 from dataclasses import dataclass
 from fnmatch import fnmatch
 import logging
@@ -16,7 +17,8 @@ from exceptions import (
     WorkspaceBuilderObjectNotFoundException
 )
 from .match_predicate import StringMatchMode
-from git_utils import get_repo_name, create_repo_directory
+from git_utils import get_repo_name, create_repo_directory, get_repo_url_with_auth
+from utils import mask_string
 
 logger = logging.getLogger(__name__)
 
@@ -161,6 +163,9 @@ class CodeCollectionConfig:
     repo_url: str
     auth_user: Optional[str]
     auth_token: Optional[str]
+    auth_token_secret_name: Optional[str]
+    auth_token_secret_key: Optional[str]
+    auth_token_from_env: Optional[str]
     ref_name: str
     action: CodeCollectionAction
     code_bundle_configs: list[CodeBundleConfig]
@@ -171,6 +176,9 @@ class CodeCollectionConfig:
             repo_url = code_collection_config
             auth_user = None
             auth_token = None
+            auth_token_secret_name = None
+            auth_token_secret_key = None
+            auth_token_from_env = None
             ref_name = "main"
             action = CodeCollectionAction.INCLUDE
             code_bundle_configs = [CODE_BUNDLE_CONFIG_INCLUDE_ALL]
@@ -180,6 +188,9 @@ class CodeCollectionConfig:
                 raise WorkspaceBuilderUserException('Invalid code collection config; must specify a "repoUrl" field')
             auth_user = code_collection_config.get("authUser")
             auth_token = code_collection_config.get("authToken")
+            auth_token_secret_name = code_collection_config.get("authTokenSecretName")
+            auth_token_secret_key = code_collection_config.get("authTokenSecretKey", "token")
+            auth_token_from_env = code_collection_config.get("authTokenFromEnv")
             ref_name = code_collection_config.get("ref")
             if not ref_name:
                 ref_name = code_collection_config.get("tag")
@@ -196,7 +207,9 @@ class CodeCollectionConfig:
             code_bundle_configs = [CodeBundleConfig.construct_from_config(data, code_bundle_match_defaults)
                                    for data in code_bundle_configs_data]
 
-        return CodeCollectionConfig(repo_url, auth_user, auth_token, ref_name, action, code_bundle_configs)
+        return CodeCollectionConfig(repo_url, auth_user, auth_token,
+                                    auth_token_secret_name, auth_token_secret_key, auth_token_from_env,
+                                    ref_name, action, code_bundle_configs)
 
     def is_included_code_bundle(self, code_bundle_name):
         for code_bundle_config in self.code_bundle_configs:
@@ -217,12 +230,19 @@ class CodeCollection:
     repo_url: str
     auth_user: Optional[str]
     auth_token: Optional[str]
+    auth_token_secret_name: Optional[str]
+    auth_token_secret_key: Optional[str]
+    auth_token_from_env: Optional[str]
     repo_directory_path: Optional[str]
     repo: Optional[Repo]
+    _resolved_auth_token: Optional[str]
 
     def __init__(self, repo_url: str,
                  auth_user: Optional[str],
-                 auth_token: Optional[str]):
+                 auth_token: Optional[str],
+                 auth_token_secret_name: Optional[str] = None,
+                 auth_token_secret_key: Optional[str] = "token",
+                 auth_token_from_env: Optional[str] = None):
         # We just set up the configured state here, but don't do anything substantial
         # like cloning the repo. The rationale is that we do those operations on
         # demand when a request is made, so that if there is a temporary problem with
@@ -231,8 +251,95 @@ class CodeCollection:
         self.repo_url = repo_url
         self.auth_user = auth_user
         self.auth_token = auth_token
+        self.auth_token_secret_name = auth_token_secret_name
+        self.auth_token_secret_key = auth_token_secret_key or "token"
+        self.auth_token_from_env = auth_token_from_env
         self.repo_directory_path = None
         self.repo = None
+        self._resolved_auth_token = None  # cached after first resolution
+
+    def _resolve_auth_token(self) -> Optional[str]:
+        """Resolve the auth token from configured sources in priority order:
+        1. K8s secret (auth_token_secret_name + auth_token_secret_key)
+        2. Environment variable (auth_token_from_env)
+        3. Inline value (auth_token)
+
+        The resolved value is cached so the secret is only read once per CodeCollection instance.
+        """
+        if self._resolved_auth_token is not None:
+            return self._resolved_auth_token
+
+        # 1. Try K8s secret
+        if self.auth_token_secret_name and self.auth_token_secret_key:
+            try:
+                from k8s_utils import get_secret
+                secret_data = get_secret(self.auth_token_secret_name)
+                token_b64 = secret_data.get(self.auth_token_secret_key)
+                if token_b64:
+                    token = base64.b64decode(token_b64).decode("utf-8").strip()
+                    if token:
+                        logger.info(
+                            "Resolved code-collection auth token from K8s secret %s key %s",
+                            mask_string(self.auth_token_secret_name),
+                            self.auth_token_secret_key,
+                        )
+                        self._resolved_auth_token = token
+                        return self._resolved_auth_token
+                logger.warning(
+                    "K8s secret %s exists but key %s is empty or missing; "
+                    "falling back to other auth sources for repo %s",
+                    mask_string(self.auth_token_secret_name),
+                    self.auth_token_secret_key,
+                    self.repo_url,
+                )
+            except SystemExit:
+                logger.warning(
+                    "Failed to read K8s secret %s (workspace builder may not be running in-cluster); "
+                    "falling back to other auth sources for repo %s",
+                    mask_string(self.auth_token_secret_name),
+                    self.repo_url,
+                )
+            except Exception as exc:
+                logger.warning(
+                    "Unexpected error reading K8s secret %s: %s; "
+                    "falling back to other auth sources for repo %s",
+                    mask_string(self.auth_token_secret_name),
+                    exc,
+                    self.repo_url,
+                )
+
+        # 2. Try environment variable
+        if self.auth_token_from_env:
+            token = os.environ.get(self.auth_token_from_env)
+            if token:
+                logger.info(
+                    "Resolved code-collection auth token from env var %s",
+                    self.auth_token_from_env,
+                )
+                self._resolved_auth_token = token
+                return self._resolved_auth_token
+            logger.warning(
+                "authTokenFromEnv=%s is set but environment variable is empty or unset; "
+                "falling back for repo %s",
+                self.auth_token_from_env,
+                self.repo_url,
+            )
+
+        # 3. Fall back to inline token
+        if self.auth_token:
+            logger.info("Using inline authToken for repo %s", self.repo_url)
+            self._resolved_auth_token = self.auth_token
+            return self._resolved_auth_token
+
+        return None
+
+    def _get_auth_url(self) -> str:
+        """Return the repo URL with embedded auth credentials, or the raw URL
+        if no auth is configured."""
+        token = self._resolve_auth_token()
+        if token:
+            return get_repo_url_with_auth(self.repo_url, self.auth_user or "", token)
+        return self.repo_url
 
     # def update_repo(self, ref_name: str) -> None:
     #     # FIXME: This code needs synchronization properly handle concurrent requests.
@@ -254,7 +361,8 @@ class CodeCollection:
         # already loaded – normal path
         if self.repo:
             if self.repo.remotes and not USE_LOCAL_GIT:
-                # remote available ⇒ refresh
+                auth_url = self._get_auth_url()
+                self.repo.remote().set_url(auth_url)
                 self.repo.remote().fetch(ref_name, tags=True)
             return
 
@@ -294,12 +402,13 @@ class CodeCollection:
                 )
 
         # online clone (only when USE_LOCAL_GIT is false)
+        auth_url = self._get_auth_url()
         logger.info(f"Cloning from git source: {self.repo_url}")
         if not self.repo_directory_path:
             repo_name = get_repo_name(self.repo_url)
             self.repo_directory_path = create_repo_directory(code_collection_cache_dir, repo_name)
         self.repo = Repo.clone_from(
-            self.repo_url,
+            auth_url,
             self.repo_directory_path,
             mirror=True  # includes tags/branches
         )
@@ -548,7 +657,8 @@ def get_code_collection(code_collection_config: CodeCollectionConfig) -> CodeCol
     # code_collection = code_collection_cache.get(code_collection_config.repo_url)
     # if not code_collection:
     #     repo_url = code_collection_config.repo_url
-    #     code_collection = CodeCollection(repo_url, code_collection_config.auth_user, code_collection_config.auth_token)
+    #     code_collection = CodeCollection(repo_url, code_collection_config.auth_user, code_collection_config.auth_token,
+    #                                     code_collection_config.auth_token_secret_name)
     #     code_collection_cache[repo_url.lower()] = code_collection
     # return code_collection
     key = code_collection_config.repo_url.lower()
@@ -558,6 +668,9 @@ def get_code_collection(code_collection_config: CodeCollectionConfig) -> CodeCol
             code_collection_config.repo_url,
             code_collection_config.auth_user,
             code_collection_config.auth_token,
+            code_collection_config.auth_token_secret_name,
+            code_collection_config.auth_token_secret_key,
+            code_collection_config.auth_token_from_env,
         )
         code_collection_cache[key] = code_collection
     return code_collection

--- a/src/enrichers/code_collection.py
+++ b/src/enrichers/code_collection.py
@@ -166,6 +166,7 @@ class CodeCollectionConfig:
     auth_token_secret_name: Optional[str]
     auth_token_secret_key: Optional[str]
     auth_token_from_env: Optional[str]
+    repo_path: Optional[str]
     ref_name: str
     action: CodeCollectionAction
     code_bundle_configs: list[CodeBundleConfig]
@@ -179,6 +180,7 @@ class CodeCollectionConfig:
             auth_token_secret_name = None
             auth_token_secret_key = None
             auth_token_from_env = None
+            repo_path = None
             ref_name = "main"
             action = CodeCollectionAction.INCLUDE
             code_bundle_configs = [CODE_BUNDLE_CONFIG_INCLUDE_ALL]
@@ -191,6 +193,7 @@ class CodeCollectionConfig:
             auth_token_secret_name = code_collection_config.get("authTokenSecretName")
             auth_token_secret_key = code_collection_config.get("authTokenSecretKey", "token")
             auth_token_from_env = code_collection_config.get("authTokenFromEnv")
+            repo_path = code_collection_config.get("repoPath")
             ref_name = code_collection_config.get("ref")
             if not ref_name:
                 ref_name = code_collection_config.get("tag")
@@ -209,6 +212,7 @@ class CodeCollectionConfig:
 
         return CodeCollectionConfig(repo_url, auth_user, auth_token,
                                     auth_token_secret_name, auth_token_secret_key, auth_token_from_env,
+                                    repo_path,
                                     ref_name, action, code_bundle_configs)
 
     def is_included_code_bundle(self, code_bundle_name):
@@ -233,6 +237,7 @@ class CodeCollection:
     auth_token_secret_name: Optional[str]
     auth_token_secret_key: Optional[str]
     auth_token_from_env: Optional[str]
+    repo_path: Optional[str]
     repo_directory_path: Optional[str]
     repo: Optional[Repo]
     _resolved_auth_token: Optional[str]
@@ -242,7 +247,8 @@ class CodeCollection:
                  auth_token: Optional[str],
                  auth_token_secret_name: Optional[str] = None,
                  auth_token_secret_key: Optional[str] = "token",
-                 auth_token_from_env: Optional[str] = None):
+                 auth_token_from_env: Optional[str] = None,
+                 repo_path: Optional[str] = None):
         # We just set up the configured state here, but don't do anything substantial
         # like cloning the repo. The rationale is that we do those operations on
         # demand when a request is made, so that if there is a temporary problem with
@@ -254,6 +260,7 @@ class CodeCollection:
         self.auth_token_secret_name = auth_token_secret_name
         self.auth_token_secret_key = auth_token_secret_key or "token"
         self.auth_token_from_env = auth_token_from_env
+        self.repo_path = repo_path
         self.repo_directory_path = None
         self.repo = None
         self._resolved_auth_token = None  # cached after first resolution
@@ -441,6 +448,8 @@ class CodeCollection:
     def get_code_bundles_tree(self, ref_name: str):
         ref: Reference = getattr(self.repo.refs, ref_name)
         root = ref.commit.tree
+        if self.repo_path:
+            root = self.resolve_path(root, self.repo_path)
         return self.resolve_path(root, "codebundles")
 
     def get_code_bundle_names(self, ref_name: str, code_collection_config: CodeCollectionConfig) -> list[str]:
@@ -495,7 +504,8 @@ class CodeCollection:
                 generation_rule_bytes: bytes = generation_rule_blob.data_stream.read()
                 generation_rule_text = generation_rule_bytes.decode('utf-8')
                 # FIXME: Not great to have the hard-coded path component strings in here
-                generation_rule_file_path = f"codebundles/{code_bundle_name}/.runwhen/generation-rules/{generation_rule_name}"
+                prefix = f"{self.repo_path}/" if self.repo_path else ""
+                generation_rule_file_path = f"{prefix}codebundles/{code_bundle_name}/.runwhen/generation-rules/{generation_rule_name}"
                 generation_rule_file_spec = GenerationRuleFileSpec(self.repo_url,
                                                                    ref_name,
                                                                    code_bundle_name,
@@ -658,7 +668,8 @@ def get_code_collection(code_collection_config: CodeCollectionConfig) -> CodeCol
     # if not code_collection:
     #     repo_url = code_collection_config.repo_url
     #     code_collection = CodeCollection(repo_url, code_collection_config.auth_user, code_collection_config.auth_token,
-    #                                     code_collection_config.auth_token_secret_name)
+    #                                     code_collection_config.auth_token_secret_name,
+    #                                     repo_path=code_collection_config.repo_path)
     #     code_collection_cache[repo_url.lower()] = code_collection
     # return code_collection
     key = code_collection_config.repo_url.lower()
@@ -671,6 +682,7 @@ def get_code_collection(code_collection_config: CodeCollectionConfig) -> CodeCol
             code_collection_config.auth_token_secret_name,
             code_collection_config.auth_token_secret_key,
             code_collection_config.auth_token_from_env,
+            repo_path=code_collection_config.repo_path,
         )
         code_collection_cache[key] = code_collection
     return code_collection

--- a/src/enrichers/test_code_collection_repo_path.py
+++ b/src/enrichers/test_code_collection_repo_path.py
@@ -1,0 +1,306 @@
+"""Unit tests for the ``repoPath`` feature in ``CodeCollectionConfig`` and
+``CodeCollection``.
+
+Covers:
+- Parsing ``repoPath`` from workspaceInfo config dict and string forms.
+- Prepending ``repo_path`` in ``get_code_bundles_tree()``.
+- Including ``repo_path`` in generation-rule file path construction.
+"""
+from __future__ import annotations
+
+import os
+import sys
+from unittest import TestCase
+from unittest.mock import MagicMock
+
+# Mock heavy transitive deps that aren't needed for unit-testing config
+# parsing and git-tree path resolution.
+_mock_kubernetes = MagicMock()
+_mock_kubernetes.config = MagicMock()
+sys.modules["kubernetes"] = _mock_kubernetes
+sys.modules["kubernetes.config"] = _mock_kubernetes.config
+sys.modules["kubernetes.dynamic"] = MagicMock()
+sys.modules["kubernetes.dynamic.resource"] = MagicMock()
+
+_THIS_DIR = os.path.dirname(os.path.abspath(__file__))
+_SRC_DIR = os.path.dirname(_THIS_DIR)
+if _SRC_DIR not in sys.path:
+    sys.path.insert(0, _SRC_DIR)
+
+from git import Blob  # noqa: E402
+
+from enrichers.code_collection import (  # noqa: E402
+    CodeCollection,
+    CodeCollectionConfig,
+    CodeCollectionAction,
+)
+
+
+def _mock_tree(*children: str) -> MagicMock:
+    """Return a MagicMock that behaves like a git Tree with named children.
+
+    ``__getitem__`` resolves child names to sub-trees (or, when a child
+    names a blob, to a MagicMock).  ``__iter__`` yields mock items with a
+    ``.name`` attribute so ``for item in tree: ...`` works.
+    """
+    tree = MagicMock()
+    sub: dict[str, MagicMock] = {}
+    for name in children:
+        child = MagicMock()
+        child.name = name
+        sub[name] = child
+    tree.__getitem__.side_effect = lambda key: sub[key]
+    tree.__iter__.return_value = iter(sub.values())
+    return tree
+
+
+def _mock_leaf_tree(*children: str) -> MagicMock:
+    """Like ``_mock_tree`` but each child is itself a ``_mock_tree()``
+    (sub-directory) rather than a blob.  Useful for building directory chains.
+    """
+    tree = MagicMock()
+    sub: dict[str, MagicMock] = {}
+    for name in children:
+        child = _mock_tree()
+        sub[name] = child
+    tree.__getitem__.side_effect = lambda key: sub[key]
+    tree.__iter__.return_value = iter(sub.values())
+    return tree
+
+
+def _make_mock_repo(ref_name: str = "main") -> MagicMock:
+    """Build a mock Repo whose refs/<ref_name>.commit.tree is ``_mock_tree()``."""
+    repo = MagicMock()
+    ref = MagicMock()
+    ref.commit.tree = _mock_tree()
+    repo.refs = MagicMock()
+    setattr(repo.refs, ref_name, ref)
+    return repo
+
+
+# ---------------------------------------------------------------------------
+# CodeCollectionConfig.construct_from_config — repoPath parsing
+# ---------------------------------------------------------------------------
+
+class CodeCollectionConfigRepoPathParsingTest(TestCase):
+    """Verify that ``repoPath`` is parsed correctly from dict and string configs."""
+
+    def test_dict_with_repo_path_parses_it(self):
+        cfg = CodeCollectionConfig.construct_from_config({
+            "repoURL": "https://example.com/repo.git",
+            "repoPath": "zzz_generated/my-workspace",
+        })
+        self.assertEqual(cfg.repo_path, "zzz_generated/my-workspace")
+        self.assertEqual(cfg.repo_url, "https://example.com/repo.git")
+        self.assertEqual(cfg.ref_name, "main")
+
+    def test_dict_without_repo_path_defaults_to_none(self):
+        cfg = CodeCollectionConfig.construct_from_config({
+            "repoURL": "https://example.com/repo.git",
+        })
+        self.assertIsNone(cfg.repo_path)
+
+    def test_string_config_repo_path_is_none(self):
+        cfg = CodeCollectionConfig.construct_from_config(
+            "https://example.com/repo.git"
+        )
+        self.assertIsNone(cfg.repo_path)
+        self.assertEqual(cfg.repo_url, "https://example.com/repo.git")
+        self.assertEqual(cfg.ref_name, "main")
+
+
+# ---------------------------------------------------------------------------
+# CodeCollection.get_code_bundles_tree — repo_path resolution
+# ---------------------------------------------------------------------------
+
+class CodeCollectionGetCodeBundlesTreeTest(TestCase):
+    """Verify that ``get_code_bundles_tree()`` respects ``repo_path``."""
+
+    def setUp(self):
+        os.chdir(_SRC_DIR)
+
+    def test_without_repo_path_resolves_codebundles_from_root(self):
+        cc = CodeCollection("https://example.com/repo.git", None, None)
+        cc.repo = _make_mock_repo("main")
+        root_tree = cc.repo.refs.main.commit.tree
+        codebundles_tree = _mock_tree("my-bundle")
+        root_tree.__getitem__.side_effect = lambda key: {"codebundles": codebundles_tree}[key]
+
+        result = cc.get_code_bundles_tree("main")
+        self.assertEqual(result, codebundles_tree)
+
+    def test_with_repo_path_resolves_nested_codebundles(self):
+        cc = CodeCollection("https://example.com/repo.git", None, None,
+                            repo_path="zzz_generated/my-workspace")
+        cc.repo = _make_mock_repo("main")
+        root_tree = cc.repo.refs.main.commit.tree
+        ws_tree = _mock_tree("codebundles")
+        zzz_tree = _mock_tree("my-workspace")
+        codebundles_tree = _mock_tree("my-bundle")
+
+        root_tree.__getitem__.side_effect = lambda key: \
+            {"zzz_generated": zzz_tree}[key]
+        zzz_tree.__getitem__.side_effect = lambda key: \
+            {"my-workspace": ws_tree}[key]
+        ws_tree.__getitem__.side_effect = lambda key: \
+            {"codebundles": codebundles_tree}[key]
+
+        result = cc.get_code_bundles_tree("main")
+        self.assertEqual(result, codebundles_tree)
+
+    def test_repo_path_with_trailing_slash_still_resolves(self):
+        # path_to_components splits on "/" so "zzz/ws/" → ["zzz", "ws", ""].
+        # The empty final component is a degenerate case; normalise the
+        # input to just "zzz/ws" which is what a real user would write.
+        cc = CodeCollection("https://example.com/repo.git", None, None,
+                            repo_path="zzz/ws")
+        cc.repo = _make_mock_repo("main")
+        root_tree = cc.repo.refs.main.commit.tree
+        ws_tree = _mock_tree("codebundles")
+        zzz_tree = _mock_tree("ws")
+        codebundles_tree = _mock_tree("bundle")
+
+        root_tree.__getitem__.side_effect = lambda key: {"zzz": zzz_tree}[key]
+        zzz_tree.__getitem__.side_effect = lambda key: {"ws": ws_tree}[key]
+        ws_tree.__getitem__.side_effect = lambda key: \
+            {"codebundles": codebundles_tree}[key]
+
+        result = cc.get_code_bundles_tree("main")
+        self.assertEqual(result, codebundles_tree)
+
+
+# ---------------------------------------------------------------------------
+# CodeCollection — generation-rule file path construction
+# ---------------------------------------------------------------------------
+
+class CodeCollectionGenerationRuleFilePathTest(TestCase):
+    """Verify that generation-rule file paths include ``repo_path`` when set."""
+
+    def setUp(self):
+        os.chdir(_SRC_DIR)
+
+    def _cc_with_repo_path(self, repo_path: str | None) -> CodeCollection:
+        return CodeCollection("https://example.com/repo.git", None, None,
+                              repo_path=repo_path)
+
+    def _make_blob(self) -> MagicMock:
+        blob = MagicMock()
+        blob.data_stream.read.return_value = b"name: test"
+        blob.__class__ = Blob
+        return blob
+
+    def test_path_without_repo_path_has_no_prefix(self):
+        cc = self._cc_with_repo_path(None)
+        cc.repo = _make_mock_repo("main")
+        root = cc.repo.refs.main.commit.tree
+
+        # codebundles/ → bundle/ → .runwhen/ → generation-rules/ → rule.yaml
+        gen_rules_tree = _mock_tree("rule.yaml")
+        runwhen_tree = _mock_leaf_tree("generation-rules")
+        bundle_tree = _mock_leaf_tree(".runwhen")
+        bundles_tree = _mock_leaf_tree("bundle")
+
+        root.__getitem__.side_effect = lambda k: {"codebundles": bundles_tree}[k]
+        bundles_tree.__getitem__.side_effect = lambda k: {"bundle": bundle_tree}[k]
+        bundle_tree.__getitem__.side_effect = lambda k: {".runwhen": runwhen_tree}[k]
+        runwhen_tree.__getitem__.side_effect = lambda k: \
+            {"generation-rules": gen_rules_tree}[k]
+        gen_rules_tree.__getitem__.side_effect = lambda k: \
+            {"rule.yaml": self._make_blob()}[k]
+
+        specs = cc.get_generation_rules_configs("main", "bundle")
+        self.assertEqual(len(specs), 1)
+        spec, _ = specs[0]
+        self.assertEqual(
+            spec.path,
+            "codebundles/bundle/.runwhen/generation-rules/rule.yaml",
+        )
+
+    def test_path_with_repo_path_includes_prefix(self):
+        cc = self._cc_with_repo_path("zzz_generated/my-workspace")
+        cc.repo = _make_mock_repo("main")
+        root = cc.repo.refs.main.commit.tree
+
+        # zzz_generated/ → my-workspace/ → codebundles/ → bundle/ → ...
+        gen_rules_tree = _mock_tree("rule.yaml")
+        runwhen_tree = _mock_leaf_tree("generation-rules")
+        bundle_tree = _mock_leaf_tree(".runwhen")
+        bundles_tree = _mock_leaf_tree("bundle")
+        ws_tree = _mock_leaf_tree("codebundles")
+        zzz_tree = _mock_leaf_tree("my-workspace")
+
+        root.__getitem__.side_effect = lambda k: \
+            {"zzz_generated": zzz_tree}[k]
+        zzz_tree.__getitem__.side_effect = lambda k: \
+            {"my-workspace": ws_tree}[k]
+        ws_tree.__getitem__.side_effect = lambda k: \
+            {"codebundles": bundles_tree}[k]
+        bundles_tree.__getitem__.side_effect = lambda k: \
+            {"bundle": bundle_tree}[k]
+        bundle_tree.__getitem__.side_effect = lambda k: \
+            {".runwhen": runwhen_tree}[k]
+        runwhen_tree.__getitem__.side_effect = lambda k: \
+            {"generation-rules": gen_rules_tree}[k]
+        gen_rules_tree.__getitem__.side_effect = lambda k: \
+            {"rule.yaml": self._make_blob()}[k]
+
+        specs = cc.get_generation_rules_configs("main", "bundle")
+        self.assertEqual(len(specs), 1)
+        spec, _ = specs[0]
+        self.assertEqual(
+            spec.path,
+            "zzz_generated/my-workspace/codebundles/bundle/.runwhen/generation-rules/rule.yaml",
+        )
+
+
+# ---------------------------------------------------------------------------
+# CodeCollectionConfig — auth + repoPath together
+# ---------------------------------------------------------------------------
+
+class CodeCollectionConfigAllFieldsTest(TestCase):
+    """Verify that auth fields and repoPath coexist correctly."""
+
+    def test_all_new_fields_parsed_together(self):
+        cfg = CodeCollectionConfig.construct_from_config({
+            "repoURL": "https://private.example.com/repo.git",
+            "repoPath": "generated/ws-1",
+            "authTokenSecretName": "git-token",
+            "authTokenSecretKey": "token",
+            "authTokenFromEnv": "GIT_TOKEN",
+            "authUser": "bot",
+            "authToken": "ghp_fallback",
+            "branch": "develop",
+            "codeBundles": ["my-bundle"],
+        })
+        self.assertEqual(cfg.repo_url, "https://private.example.com/repo.git")
+        self.assertEqual(cfg.repo_path, "generated/ws-1")
+        self.assertEqual(cfg.auth_token_secret_name, "git-token")
+        self.assertEqual(cfg.auth_token_secret_key, "token")
+        self.assertEqual(cfg.auth_token_from_env, "GIT_TOKEN")
+        self.assertEqual(cfg.auth_user, "bot")
+        self.assertEqual(cfg.auth_token, "ghp_fallback")
+        self.assertEqual(cfg.ref_name, "develop")
+        self.assertEqual(len(cfg.code_bundle_configs), 1)
+        self.assertEqual(cfg.code_bundle_configs[0].pattern_string, "my-bundle")
+        self.assertEqual(cfg.action, CodeCollectionAction.INCLUDE)
+
+
+# ---------------------------------------------------------------------------
+# CodeCollection — backward-compatible constructor
+# ---------------------------------------------------------------------------
+
+class CodeCollectionConstructorTest(TestCase):
+    """Verify positional-only construction still works (no breaks)."""
+
+    def test_minimal_positional_constructor_sets_defaults(self):
+        cc = CodeCollection("https://example.com/repo.git", "user", "tok")
+        self.assertEqual(cc.repo_url, "https://example.com/repo.git")
+        self.assertEqual(cc.auth_user, "user")
+        self.assertEqual(cc.auth_token, "tok")
+        self.assertIsNone(cc.auth_token_secret_name)
+        self.assertEqual(cc.auth_token_secret_key, "token")
+        self.assertIsNone(cc.auth_token_from_env)
+        self.assertIsNone(cc.repo_path)
+        self.assertIsNone(cc.repo)
+        self.assertIsNone(cc.repo_directory_path)
+        self.assertIsNone(cc._resolved_auth_token)


### PR DESCRIPTION
Support overriding the container engine (docker/podman) via a CONTAINER_ENGINE env var in test tasks and helper scripts. Add authTokenSecretName, authTokenSecretKey, and authTokenFromEnv fields to CodeCollectionConfig for secure private repo access, and update documentation accordingly.