### PR TITLE
Bump SLX name limit to 255, add collision detection

### DIFF
--- a/src/VERSION
+++ b/src/VERSION
@@ -1,4 +1,4 @@
 {
   "name": "runwhen-local",
-  "version": "0.11.9"
+  "version": "0.11.10"
 }

--- a/src/enrichers/generation_rules.py
+++ b/src/enrichers/generation_rules.py
@@ -25,7 +25,7 @@ from component import (
 )
 from exceptions import WorkspaceBuilderException, WorkspaceBuilderUserException
 from indexers.kubetypes import KUBERNETES_PLATFORM
-from name_utils import shorten_name, make_qualified_slx_name, make_slx_name, make_slx_name_and_qualified
+from name_utils import MAX_SLX_NAME_LENGTH, shorten_name, make_qualified_slx_name, make_slx_name, make_slx_name_and_qualified
 from .generation_rule_types import (
     PLATFORM_HANDLERS_PROPERTY_NAME,
     PlatformHandler,
@@ -1000,9 +1000,10 @@ def collect_emitted_slxs(generation_rule_info: GenerationRuleInfo,
 
 
 def assign_slx_names(slxs: dict[str, SLXInfo], workspace_name):
+    max_qualified_length = MAX_SLX_NAME_LENGTH - len(workspace_name) - 2  # 2 for "--"
     slxs_by_default_shortened_name: dict[str, list[SLXInfo]] = dict()
     for slx_info in slxs.values():
-        shortened_name = make_qualified_slx_name(slx_info.slx.shortened_base_name, slx_info.qualifier_values)
+        shortened_name = make_qualified_slx_name(slx_info.slx.shortened_base_name, slx_info.qualifier_values, max_qualified_length)
         slx_list = slxs_by_default_shortened_name.get(shortened_name)
         if not slx_list:
             slx_list = []
@@ -1030,13 +1031,32 @@ def assign_slx_names(slxs: dict[str, SLXInfo], workspace_name):
                 # IMPORTANT: Use shortened_base_name, not base_name, to keep qualified names short
                 # Using base_name here was a bug that caused qualified names to exceed expected length
                 indexed_base_name = f"{slx_info.slx.shortened_base_name}{i+1}"
-                initial_qualified_name = make_qualified_slx_name(indexed_base_name, slx_info.qualifier_values)
+                initial_qualified_name = make_qualified_slx_name(indexed_base_name, slx_info.qualifier_values, max_qualified_length)
                 # Use make_slx_name_and_qualified to ensure directory name matches SLX name
                 slx_info.name, slx_info.qualified_name = make_slx_name_and_qualified(workspace_name, initial_qualified_name)
         else:
             slx_info = slx_list[0]
             # Use make_slx_name_and_qualified to ensure directory name matches SLX name
             slx_info.name, slx_info.qualified_name = make_slx_name_and_qualified(workspace_name, shortened_name)
+
+    # Final-name collision detection: group by post-sanitization final name
+    # to catch collisions from sanitize_name() collapsing distinct qualified names
+    slxs_by_final_name: dict[str, list[SLXInfo]] = dict()
+    for slx_info in slxs.values():
+        slxs_by_final_name.setdefault(slx_info.name, []).append(slx_info)
+    for final_name, colliding in slxs_by_final_name.items():
+        if len(colliding) > 1:
+            logger.warning(
+                "SLX final-name collision detected after sanitization: %d SLXs share name '%s'. "
+                "Disambiguating by appending incrementing integers.",
+                len(colliding), final_name,
+            )
+            for i, slx_info in enumerate(colliding):
+                indexed_base_name = f"{slx_info.slx.shortened_base_name}{i+1}"
+                initial_qualified_name = make_qualified_slx_name(
+                    indexed_base_name, slx_info.qualifier_values, max_qualified_length)
+                slx_info.name, slx_info.qualified_name = make_slx_name_and_qualified(
+                    workspace_name, initial_qualified_name)
 
 
 class SLXRelationship:

--- a/src/name_utils.py
+++ b/src/name_utils.py
@@ -3,6 +3,7 @@ import hashlib
 
 # Regex metacharacters that distinguish a regex pattern from a plain string.
 _REGEX_METACHARS = frozenset(".*+?^$[]{}()\\")
+MAX_SLX_NAME_LENGTH = 255
 
 
 def matches_namespace(namespace_name: str, patterns: list[str] | None) -> bool:
@@ -145,11 +146,6 @@ def _truncate_qualified_name(qualified_slx_name: str, excess_length: int) -> str
         return qualified_slx_name[:-excess_length]
 
 
-class SLXNameValidationError(Exception):
-    """Raised when an SLX name fails validation (e.g., exceeds max length)."""
-    pass
-
-
 def make_slx_name_and_qualified(workspace_name: str, qualified_slx_name: str) -> tuple[str, str]:
     """
     Create an SLX name and return both the full name and the (possibly truncated) qualified name.
@@ -159,31 +155,29 @@ def make_slx_name_and_qualified(workspace_name: str, qualified_slx_name: str) ->
     :return: A tuple of (full_slx_name, truncated_qualified_name) where:
              - full_slx_name is the combined and sanitized SLX name (workspace--qualified)
              - truncated_qualified_name is the (possibly truncated) qualified name for directory use
-    :raises SLXNameValidationError: If the final name exceeds 63 characters after all processing.
+    :raises ValueError: If the final name exceeds MAX_SLX_NAME_LENGTH characters after all processing.
     """
-    max_k8s_name_length = 63
     combined_length = len(workspace_name) + 2 + len(qualified_slx_name)  # 2 for the "--" separator
-    if combined_length > max_k8s_name_length:
-        excess_length = combined_length - max_k8s_name_length
+    if combined_length > MAX_SLX_NAME_LENGTH:
+        excess_length = combined_length - MAX_SLX_NAME_LENGTH
         qualified_slx_name = _truncate_qualified_name(qualified_slx_name, excess_length)
     safe_qualified_slx_name = sanitize_name(qualified_slx_name)
     full_slx_name = f"{workspace_name}--{safe_qualified_slx_name}"
-    
-    # CRITICAL VALIDATION: Ensure the final name does not exceed 63 characters
-    # This is a hard requirement for Kubernetes resource names and labels
-    if len(full_slx_name) > max_k8s_name_length:
-        raise SLXNameValidationError(
+
+    # CRITICAL VALIDATION: Ensure the final name does not exceed the maximum length
+    if len(full_slx_name) > MAX_SLX_NAME_LENGTH:
+        raise ValueError(
             f"SLX name '{full_slx_name}' is {len(full_slx_name)} characters, "
-            f"exceeding the Kubernetes limit of {max_k8s_name_length}. "
+            f"exceeding the limit of {MAX_SLX_NAME_LENGTH}. "
             f"Workspace: '{workspace_name}', Qualified name: '{safe_qualified_slx_name}'"
         )
-    
+
     return (full_slx_name, safe_qualified_slx_name)
 
 
 def make_slx_name(workspace_name: str, qualified_slx_name: str) -> str:
     """
-    Ensure the SLX name is safe for file naming and fits within the Kubernetes name limit.
+    Ensure the SLX name is safe for file naming.
     :param workspace_name: The workspace name.
     :param qualified_slx_name: The qualified SLX name.
     :return: The combined and sanitized SLX name.
@@ -195,19 +189,16 @@ def make_slx_name(workspace_name: str, qualified_slx_name: str) -> str:
     full_name, _ = make_slx_name_and_qualified(workspace_name, qualified_slx_name)
     return full_name
 
-def make_qualified_slx_name(base_name: str, qualifiers: list[str], max_length=23) -> str:
+def make_qualified_slx_name(base_name: str, qualifiers: list[str], max_length=None) -> str:
     """
     This returns the qualified (shortened) SLX name but doesn't include
     the workspace name prefix. This would be used for the name of the SLX
     directory in the workspace.
     Note: the default value for the max_length is derived from the way we encode
-    information into the resource name and the Kubernetes 64-character limit on
-    length of the name. Hopefully in the future we'll handle this differently
-    such that we don't need to do these name shortening tricks to fix into
-    64 characters.
+    information into the resource name and the platform's 255-character DB limit.
     :param base_name: The base name of the SLX.
     :param qualifiers: The list of qualifiers.
-    :param max_length: The maximum length of the qualified SLX name.
+    :param max_length: The maximum length of the qualified SLX name (defaults to 255).
     :return: The sanitized and shortened qualified SLX name.
     """
     if not max_length:

--- a/src/tests.py
+++ b/src/tests.py
@@ -124,15 +124,15 @@ class NameUtilsTest(TestCase):
     def test_qualifier_with_underscore(self):
         qualifiers = ["my_cl", "dev_ns"]
         qualified_slx_name = make_qualified_slx_name("test", qualifiers)
-        self.assertEqual("mc-dn-test-57e43d2d", qualified_slx_name)
+        self.assertEqual("my-cl-dev-ns-test-57e43d2d", qualified_slx_name)
         slx_name = make_slx_name("my-workspace", qualified_slx_name)
-        self.assertEqual("my-workspace--mc-dn-test-57e43d2d", slx_name)
+        self.assertEqual("my-workspace--my-cl-dev-ns-test-57e43d2d", slx_name)
         qualified_slx_name = make_qualified_slx_name("statefulset-health", ["argo-cd-argocd-application-controller"])
-        self.assertEqual("acaac-statefulset-health-5fb369e9", qualified_slx_name)
+        self.assertEqual("argo-cd-argocd-application-controller-statefulset-health-5fb369e9", qualified_slx_name)
         shortened_base_name = shorten_name("statefulset-health", 15)
         self.assertEqual("sttflst-hlth", shortened_base_name)
         qualified_slx_name = make_qualified_slx_name(shortened_base_name, ["argo-cd-argocd-application-controller"])
-        self.assertEqual("acaac-sttflst-hlth-5fb369e9", qualified_slx_name)
+        self.assertEqual("argo-cd-argocd-application-controller-sttflst-hlth-5fb369e9", qualified_slx_name)
 
     def test_slx_name_truncation_preserves_hash(self):
         """Test that truncation preserves the unique hash suffix to avoid collisions."""
@@ -152,11 +152,6 @@ class NameUtilsTest(TestCase):
         self.assertNotEqual(slx_name_1, slx_name_2, "SLX names should be unique")
         self.assertNotEqual(slx_name_2, slx_name_3, "SLX names should be unique")
         self.assertNotEqual(slx_name_1, slx_name_3, "SLX names should be unique")
-        
-        # All names should respect the 63 character limit
-        self.assertLessEqual(len(slx_name_1), 63, "SLX name should not exceed 63 chars")
-        self.assertLessEqual(len(slx_name_2), 63, "SLX name should not exceed 63 chars")
-        self.assertLessEqual(len(slx_name_3), 63, "SLX name should not exceed 63 chars")
         
         # The hash suffix should be preserved in each name
         self.assertTrue(slx_name_1.endswith("1cf48ae4"), f"Hash suffix missing: {slx_name_1}")
@@ -181,9 +176,6 @@ class NameUtilsTest(TestCase):
         # Both should preserve the hash suffix
         self.assertTrue(full_name.endswith("5d24bd46"), f"Hash suffix missing from SLX name: {full_name}")
         self.assertTrue(directory_name.endswith("5d24bd46"), f"Hash suffix missing from directory: {directory_name}")
-        
-        # SLX name must fit in 63 chars
-        self.assertLessEqual(len(full_name), 63, f"SLX name too long: {len(full_name)}")
         
         # Test multiple qualified names to ensure no collisions in directories
         qualified_names = [
@@ -215,9 +207,6 @@ class NameUtilsTest(TestCase):
         
         full_name, directory_name = make_slx_name_and_qualified(long_workspace, no_hash_name)
         
-        # Should still fit in 63 chars
-        self.assertLessEqual(len(full_name), 63, f"SLX name too long: {len(full_name)}")
-        
         # Directory should match qualified portion
         self.assertEqual(directory_name, full_name.split('--')[1])
         
@@ -226,6 +215,15 @@ class NameUtilsTest(TestCase):
         # For example, "without-any-hash" should NOT become "without--any-hash" 
         # (incorrectly preserving "-any-hash" as if it were a hash suffix)
         self.assertNotIn('--', directory_name, "Should not have double dashes from incorrect hash detection")
+
+    def test_long_names_no_longer_rejected(self):
+        """Names exceeding the legacy 63-char K8s limit must pass through untruncated."""
+        long_workspace = "wba-rpu-nprod-general"
+        long_qualified = "argo-cd-argocd-application-controller-statefulset-health-5fb369e9"
+        full_name, directory_name = make_slx_name_and_qualified(long_workspace, long_qualified)
+        self.assertGreater(len(full_name), 63)
+        self.assertEqual(directory_name, long_qualified)
+        self.assertTrue(full_name.endswith("5fb369e9"))
 
     def test_matches_namespace_exact(self):
         """Exact names match, non-matching names do not."""


### PR DESCRIPTION
Remove hardcoded 63-char K8s name limit and replace with a MAX_SLX_NAME_LENGTH constant of 255 characters. Remove SLXNameValidationError.

In the generation rules enricher, compute max qualified length from the workspace name and pass it to make_qualified_slx_name. Add a final-name collision detection step after sanitization to handle cases where sanitize_name() collapses distinct qualified names into the same final name.

Update tests to reflect the new limits and verify name generation without truncation for short workspaces.