### PR TITLE
Report GCP discovery failures accurately instead of as benign CAI notes

### DIFF
--- a/docs/authoring/indexed-resources/aws-resource-catalog.md
+++ b/docs/authoring/indexed-resources/aws-resource-catalog.md
@@ -2,7 +2,7 @@
 
 Resource types the native `awsapi` indexer can discover. Use the canonical CloudQuery table name (or any listed alias) as the `resourceTypes` value in a generation rule. This page is the companion catalog for [`aws.md`](./aws.md); see that page for how to enable the indexer and what data each row carries.
 
-_1119 resource types - 3 typed (rich-payload), 1116 generic (Cloud Control envelope). Generated 2026-08-04 from `src/indexers/aws_resource_type_registry.yaml`._
+_1119 resource types - 3 typed (rich-payload), 1116 generic (Cloud Control envelope). Generated 2026-08-07 from `src/indexers/aws_resource_type_registry.yaml`._
 
 _Regenerate with `python scripts/aws/dump_aws_resource_catalog.py` after touching the registry or overrides; do not hand-edit this file._
 

--- a/docs/authoring/indexed-resources/azure-resource-catalog.md
+++ b/docs/authoring/indexed-resources/azure-resource-catalog.md
@@ -2,7 +2,7 @@
 
 Resource types the native `azureapi` indexer can discover. Use the canonical CloudQuery table name (or any listed alias) as the `resourceTypes` value in a generation rule. This page is the companion catalog for [`azure.md`](./azure.md); see that page for how to enable the indexer and what data each row carries.
 
-_619 resource types - 25 typed (rich-payload), 594 generic (basic envelope). Generated 2026-08-04 from `src/indexers/azure_resource_type_registry.yaml`._
+_619 resource types - 25 typed (rich-payload), 594 generic (basic envelope). Generated 2026-08-07 from `src/indexers/azure_resource_type_registry.yaml`._
 
 _Regenerate with `python scripts/azure/dump_azure_resource_catalog.py` after touching the registry or overrides; do not hand-edit this file._
 

--- a/docs/authoring/indexed-resources/gcp-resource-catalog.md
+++ b/docs/authoring/indexed-resources/gcp-resource-catalog.md
@@ -2,7 +2,7 @@
 
 Resource types the native `gcpapi` indexer can discover. Use the canonical CloudQuery table name (or any listed alias) as the `resourceTypes` value in a generation rule. This page is the companion catalog for [`gcp.md`](./gcp.md); see that page for how to enable the indexer and what data each row carries.
 
-_404 resource types - 13 typed (SDK collectors), 391 generic (Cloud Asset Inventory pass). Generated 2026-08-04 from `src/indexers/gcp_resource_type_registry.yaml`._
+_404 resource types - 13 typed (SDK collectors), 391 generic (Cloud Asset Inventory pass). Generated 2026-08-07 from `src/indexers/gcp_resource_type_registry.yaml`._
 
 _Regenerate with `python scripts/gcp/dump_gcp_resource_catalog.py` after touching the registry or overrides; do not hand-edit this file._
 

--- a/docs/authoring/indexed-resources/kubernetes-resource-catalog.md
+++ b/docs/authoring/indexed-resources/kubernetes-resource-catalog.md
@@ -2,7 +2,7 @@
 
 Built-in Kubernetes resource types the kubeapi indexer discovers.
 
-_Generated 2026-08-04 from `indexers/kubetypes.py`._
+_Generated 2026-08-07 from `indexers/kubetypes.py`._
 
 Custom CRDs are declared in generation rules (`resourceTypes`) and indexed
 selectively — they are not listed here.

--- a/docs/authoring/indexed-resources/runwhen-platform-resource-catalog.md
+++ b/docs/authoring/indexed-resources/runwhen-platform-resource-catalog.md
@@ -2,7 +2,7 @@
 
 Resource types indexed under `platform: runwhen`.
 
-_Generated 2026-08-04 from `scripts/runwhen/dump_runwhen_resource_catalog.py`._
+_Generated 2026-08-07 from `scripts/runwhen/dump_runwhen_resource_catalog.py`._
 
 | Resource type | Match names | Typed collector | Notes |
 |---|---|---|---|

--- a/src/indexers/gcpapi.py
+++ b/src/indexers/gcpapi.py
@@ -178,11 +178,40 @@ def _resolve_platform_handler(context: Context) -> PlatformHandler:
     return GCPPlatformHandler()
 
 
+# Markers of the process being unable to obtain credentials at all, as opposed
+# to a specific API refusing a specific caller. These surface as 403s whose text
+# also contains "permission", so without an explicit check the string fallback
+# in ``_is_permission_denied`` misfiles a total auth outage as an absent
+# optional accelerator.
+_CREDENTIALS_FAILURE_MARKERS = (
+    "unable to generate access token",
+    "iam.serviceaccounts.getaccesstoken",
+    "metadata.google.internal",
+    "compute engine metadata",
+    "could not automatically determine credentials",
+)
+
+
+def _is_credentials_failure(exc: Exception) -> bool:
+    """True when the workload could not mint a token for *any* Google API.
+
+    This is never a CAI-specific condition: if credentials cannot be obtained,
+    the typed SDK collectors are equally dead, so the failure must surface as a
+    real error rather than as the benign "optional accelerator unavailable"
+    note."""
+    text = str(exc).lower()
+    return any(marker in text for marker in _CREDENTIALS_FAILURE_MARKERS)
+
+
 def _is_permission_denied(exc: Exception) -> bool:
     """Best-effort detection of a GCP 403 / PermissionDenied without importing
     the google SDK exception types at module scope (keeps this module importable
     where the SDK is absent). Covers both the gRPC ``PermissionDenied`` and the
     REST ``Forbidden`` shapes, plus a string fallback."""
+    # Checked first: a credentials outage can arrive wrapped in any exception
+    # type, including a genuine PermissionDenied.
+    if _is_credentials_failure(exc):
+        return False
     if type(exc).__name__ in ("PermissionDenied", "Forbidden"):
         return True
     code = getattr(exc, "code", None)
@@ -201,27 +230,35 @@ def _is_permission_denied(exc: Exception) -> bool:
     return "403" in text and "permission" in text
 
 
-def _note_cai_unavailable(context: Context, project_id: str, exc: Exception) -> None:
-    """Note, informationally, that the OPTIONAL Cloud Asset Inventory generic
-    pass was not accessible for this project.
+def _note_cai_unavailable(
+    context: Context,
+    project_id: str,
+    exc: Exception,
+    missing_type_names: list[str],
+) -> None:
+    """Report that the Cloud Asset Inventory pass was denied for this project.
 
-    CAI is an accelerator that broadens coverage to resource types without a
-    typed collector; it is NOT required for native GCP discovery. The per-service
-    typed SDK collectors are the supported functional path and run independently
-    of CAI, so a 403 / disabled-API here is normal and non-fatal. This is logged
-    at INFO (no error, no banner, no warning) so CAI's absence never reads as a
-    failure or fails CI."""
+    CAI is an optional accelerator *in general*, but the CAI pass only runs at
+    all when the workspace's generation rules reference resource types that have
+    no typed SDK collector (see ``generic_cai_types`` in :func:`index`). So by
+    the time this is reached, those types are genuinely absent from the built
+    workspace. That is actionable, so it is reported as a warning naming exactly
+    what went missing rather than as a blanket "no action needed" note.
+
+    Resource types that do have a typed collector are unaffected and are not
+    listed."""
+    missing = ", ".join(sorted(missing_type_names))
     message = (
         f"{CAI_PERMISSION_DENIED_TOKEN}: Cloud Asset Inventory was not accessible "
-        f"for GCP project '{project_id}' ({exc}). This is informational, not an "
-        f"error: CAI is an OPTIONAL accelerator that broadens coverage to resource "
-        f"types lacking a typed collector. The per-service typed SDK collectors "
-        f"(compute, storage, GKE, Pub/Sub, IAM, ...) are the functional discovery "
-        f"path and continue to run normally. Enabling the Cloud Asset Inventory API "
-        f"with a CAI viewer role is optional and only increases coverage breadth; "
-        f"it is not required, so no action is needed."
+        f"for GCP project '{project_id}' ({exc}). {len(missing_type_names)} "
+        f"resource type(s) referenced by your generation rules have no typed SDK "
+        f"collector and were therefore NOT discovered in this run: {missing}. To "
+        f"discover them, enable the cloudasset.googleapis.com API on the project "
+        f"and grant roles/cloudasset.viewer to the discovery service account. "
+        f"Resource types served by a typed collector are unaffected."
     )
-    logger.info(message)
+    logger.warning(message)
+    context.add_warning(message)
 
 
 # ---------------------------------------------------------------------------
@@ -468,9 +505,18 @@ def index(context: Context) -> None:
                 assets = list(collect_assets_for_project(credentials, pid, cai_filter))
             except Exception as e:
                 if _is_permission_denied(e):
-                    # Optional accelerator unavailable: informational, not an error.
+                    # Accelerator denied: the CAI-only types the gen rules asked
+                    # for are missing from this run. Reported as a warning.
                     stats["cai_permission_denied"] += 1
-                    _note_cai_unavailable(context, pid, e)
+                    _note_cai_unavailable(
+                        context,
+                        pid,
+                        e,
+                        [
+                            spec.resource_type_name
+                            for spec in generic_cai_types.values()
+                        ],
+                    )
                 else:
                     stats["skipped_collector_error"] += 1
                     logger.error(
@@ -524,11 +570,15 @@ def index(context: Context) -> None:
         f"cai_permission_denied={stats['cai_permission_denied']}"
     )
 
-    if stats["cai_permission_denied"]:
+    # Only reassure about the CAI accelerator when the typed baseline actually
+    # delivered something. If it collected nothing, discovery did not "complete
+    # via the typed SDK collectors" and saying so hides the real failure.
+    if stats["cai_permission_denied"] and stats["added_typed"]:
         logger.info(
             "GCP discovery completed via the typed SDK collectors; the OPTIONAL "
             "Cloud Asset Inventory accelerator was not accessible this run (see %s "
-            "above). This is expected when CAI is not enabled and does not indicate "
-            "a failure -- the typed collectors are the functional discovery path.",
+            "above). The typed collectors are the functional discovery path and "
+            "did return resources; only the CAI-only types listed above are "
+            "missing.",
             CAI_PERMISSION_DENIED_TOKEN,
         )

--- a/src/indexers/test_gcpapi_cai_reporting.py
+++ b/src/indexers/test_gcpapi_cai_reporting.py
@@ -1,0 +1,230 @@
+"""
+Tests for how the GCP indexer *reports* a failed Cloud Asset Inventory pass.
+
+CAI is an optional accelerator, so a genuine CAI permission denial is
+informational. Two things must not be swept into that "informational" bucket:
+
+* A **credentials failure** (the pod cannot mint a token for *any* Google API).
+  Its text happens to contain both "403" and "permission", which the
+  best-effort string fallback in ``_is_permission_denied`` used to match --
+  reporting a total auth outage as "CAI not enabled, no action needed".
+
+* A CAI denial when the workspace's generation rules reference resource types
+  that **only** CAI can discover. Those types silently go missing, so the
+  operator does have action to take.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from unittest import TestCase, mock
+
+_THIS_DIR = os.path.dirname(os.path.abspath(__file__))
+_SRC_DIR = os.path.dirname(_THIS_DIR)
+if _SRC_DIR not in sys.path:
+    sys.path.insert(0, _SRC_DIR)
+
+from indexers import gcpapi  # noqa: E402
+from indexers.gcpapi_resource_types import GcpResourceTypeSpec  # noqa: E402
+
+
+# The verbatim shape of a Workload-Identity token-minting failure, as seen in
+# the workspace-builder log. Note it contains both "403" and "permission".
+TOKEN_MINTING_FAILURE_TEXT = (
+    "Timeout of 60.0s exceeded, last exception: 503 Getting metadata from "
+    "plugin failed with error: ('Failed to retrieve "
+    "http://metadata.google.internal/computeMetadata/v1/instance/"
+    "service-accounts/default/token?scopes=https%3A%2F%2Fwww.googleapis.com"
+    "%2Fauth%2Fcloud-platform from the Google Compute Engine metadata "
+    "service. Status: 403 Response:\\nb\"Unable to generate access token; IAM "
+    "returned 403 Forbidden: Permission 'iam.serviceAccounts.getAccessToken' "
+    "denied on resource (or it may not exist)."
+)
+
+
+class PermissionDenied(Exception):
+    """Stand-in for google.api_core.exceptions.PermissionDenied."""
+
+
+class PermissionDeniedClassificationTests(TestCase):
+    def test_token_minting_failure_is_not_a_cai_denial(self):
+        # A credentials outage must never be classified as "CAI unavailable",
+        # even though its text matches the "403"+"permission" string fallback.
+        exc = Exception(TOKEN_MINTING_FAILURE_TEXT)
+        self.assertFalse(gcpapi._is_permission_denied(exc))
+
+    def test_genuine_cai_denial_is_still_classified_as_permission_denied(self):
+        # Regression guard for the behaviour we must keep.
+        exc = PermissionDenied("403 The caller does not have permission")
+        self.assertTrue(gcpapi._is_permission_denied(exc))
+
+    def test_vpc_service_controls_denial_is_not_a_cai_denial(self):
+        # An org-policy/VPC-SC block is an actionable infrastructure problem,
+        # not an absent optional accelerator.
+        exc = Exception(
+            "403 GET https://storage.googleapis.com/storage/v1/b: Request is "
+            "prohibited by organization's policy. "
+            "vpcServiceControlsUniqueIdentifier: PO3GSM7cdmQd4QkgNSWcpRbyGgP"
+        )
+        self.assertFalse(gcpapi._is_permission_denied(exc))
+
+
+class _FakeRuleSpec:
+    def __init__(self, resource_type_name):
+        self.resource_type_name = resource_type_name
+
+
+class CaiUnavailableReportingTests(TestCase):
+    """Drive index() with a denied CAI pass and inspect what gets reported."""
+
+    def setUp(self):
+        self.warnings: list[str] = []
+
+        self.project_spec = GcpResourceTypeSpec(
+            resource_type_name="project",
+            cloudquery_table_name=gcpapi.PROJECTS_TABLE,
+            cai_asset_type=None,
+            mandatory=True,
+            typed=True,
+            collector=None,
+        )
+        # CAI-only: no typed collector, so it vanishes when CAI is denied.
+        self.sql_spec = GcpResourceTypeSpec(
+            resource_type_name="gcp_sql_instances",
+            cloudquery_table_name="gcp_sql_instances",
+            cai_asset_type="sqladmin.googleapis.com/Instance",
+            mandatory=False,
+            typed=False,
+            collector=None,
+        )
+
+        def _typed_collector(credentials, project_id):
+            if self.typed_raises is not None:
+                raise self.typed_raises
+            return []
+
+        self.typed_raises: Exception | None = None
+        self.compute_spec = GcpResourceTypeSpec(
+            resource_type_name="gcp_compute_instances",
+            cloudquery_table_name="gcp_compute_instances",
+            cai_asset_type="compute.googleapis.com/Instance",
+            mandatory=False,
+            typed=True,
+            collector=_typed_collector,
+        )
+
+        self._by_name = {
+            "gcp_projects": self.project_spec,
+            "gcp_sql_instances": self.sql_spec,
+            "gcp_compute_instances": self.compute_spec,
+        }
+        self._by_cai = {
+            "sqladmin.googleapis.com/Instance": self.sql_spec,
+            "compute.googleapis.com/Instance": self.compute_spec,
+        }
+
+    def _run(self, *, accessed, cai_exception):
+        from enrichers.generation_rules import RESOURCE_TYPE_SPECS_PROPERTY
+        from enrichers.generation_rule_types import PLATFORM_HANDLERS_PROPERTY_NAME
+
+        platform_cfg = {"projects": ["proj-a"], "projectLevelOfDetails": {}}
+        rule_specs = {"gcp": {_FakeRuleSpec(n): {} for n in accessed}}
+        outer = self
+
+        def _stub_cai(credentials, project_id, asset_types=None):
+            raise cai_exception
+
+        handler = mock.MagicMock()
+        handler.parse_resource_data.return_value = ("nm", "q/nm", {})
+
+        class FakeContext:
+            def __init__(self):
+                self._cloud = {"gcp": dict(platform_cfg)}
+                self._props = {RESOURCE_TYPE_SPECS_PROPERTY: rule_specs}
+
+            def get_setting(self, setting):
+                name = getattr(setting, "name", setting)
+                return {
+                    "GCP_INDEXER_BACKEND": "gcpapi",
+                    "CLOUD_CONFIG": self._cloud,
+                    "RESOURCE_STORE_BACKEND": "memory",
+                    "RESOURCE_STORE_PATH": None,
+                    "DEFAULT_LOD": None,
+                }.get(name)
+
+            def get_property(self, name):
+                if name == PLATFORM_HANDLERS_PROPERTY_NAME:
+                    return None
+                return self._props.get(name)
+
+            def add_warning(self, msg):
+                outer.warnings.append(msg)
+
+        with mock.patch.object(
+            gcpapi, "gcp_get_credentials_and_projects",
+            return_value={
+                "credentials": object(),
+                "project_ids": ["proj-a"],
+                "quota_project": "proj-a",
+                "env": {},
+            },
+        ), mock.patch.object(gcpapi, "get_resource_writer", return_value=mock.MagicMock()), \
+            mock.patch.object(gcpapi, "_resolve_platform_handler", return_value=handler), \
+            mock.patch.object(gcpapi, "collect_assets_for_project", _stub_cai), \
+            mock.patch.object(gcpapi, "find_spec", side_effect=lambda n: self._by_name.get(n)), \
+            mock.patch.object(
+                gcpapi, "find_spec_by_cai_type",
+                side_effect=lambda t: self._by_cai.get(t),
+            ), \
+            mock.patch("enrichers.gcp.set_gcp_credentials"):
+            with self.assertLogs(gcpapi.logger, level="INFO") as captured:
+                gcpapi.index(FakeContext())
+        return captured
+
+    def test_warns_and_names_types_when_gen_rules_need_cai_only_types(self):
+        # gcp_sql_instances is CAI-only, so a denied CAI pass means it is
+        # simply missing from the workspace -- an actionable failure.
+        captured = self._run(
+            accessed=["gcp_sql_instances"],
+            cai_exception=PermissionDenied("403 The caller does not have permission"),
+        )
+        warning_text = "\n".join(
+            r.getMessage() for r in captured.records if r.levelname == "WARNING"
+        )
+        self.assertIn("gcp_sql_instances", warning_text)
+        self.assertIn("gcp_sql_instances", "\n".join(self.warnings))
+
+    def test_does_not_claim_no_action_needed_when_types_are_missing(self):
+        captured = self._run(
+            accessed=["gcp_sql_instances"],
+            cai_exception=PermissionDenied("403 The caller does not have permission"),
+        )
+        all_text = "\n".join(r.getMessage() for r in captured.records)
+        self.assertNotIn("no action is needed", all_text)
+
+    def test_names_every_missing_cai_only_type(self):
+        # Typed types are served by their SDK collector and must NOT be listed
+        # as missing; only the CAI-only ones are actually lost.
+        captured = self._run(
+            accessed=["gcp_sql_instances", "gcp_compute_instances"],
+            cai_exception=PermissionDenied("403 The caller does not have permission"),
+        )
+        warning_text = "\n".join(
+            r.getMessage() for r in captured.records if r.levelname == "WARNING"
+        )
+        self.assertIn("gcp_sql_instances", warning_text)
+        self.assertNotIn("gcp_compute_instances", warning_text)
+
+    def test_no_success_summary_when_typed_baseline_collected_nothing(self):
+        # Typed collectors all failed AND CAI was denied: discovery produced no
+        # real resources, so the reassuring summary must not be emitted.
+        # Both a typed and a CAI-only type are referenced so that the CAI pass
+        # actually runs (it is gated on there being CAI-only types).
+        self.typed_raises = Exception("boom")
+        captured = self._run(
+            accessed=["gcp_compute_instances", "gcp_sql_instances"],
+            cai_exception=PermissionDenied("403 The caller does not have permission"),
+        )
+        all_text = "\n".join(r.getMessage() for r in captured.records)
+        self.assertNotIn("does not indicate a failure", all_text)

--- a/src/indexers/test_gcpapi_selective.py
+++ b/src/indexers/test_gcpapi_selective.py
@@ -384,36 +384,38 @@ class CaiPermissionDeniedTests(TestCase):
             mock.patch.object(gcpapi, "find_spec", side_effect=lambda n: by_name.get(n)), \
             mock.patch.object(gcpapi, "find_spec_by_cai_type", side_effect=lambda t: None), \
             mock.patch("enrichers.gcp.set_gcp_credentials"):
-            # CAI is an OPTIONAL accelerator: a 403 must be logged informationally
-            # (INFO), never raised, and never elevated to a warning/error. It must
+            # A denied CAI pass must be surfaced (the gen rules referenced a
+            # CAI-only type, so that type is now missing), never raised, and must
             # not abort discovery (the project anchor is still written).
             with self.assertLogs(gcpapi.logger, level="INFO") as captured:
                 gcpapi.index(FakeContext())
 
         joined_logs = "\n".join(captured.output)
 
-        # The stable, grep-able token is emitted at INFO (not ERROR).
+        # The stable, grep-able token is emitted at WARNING: the CAI pass only
+        # runs when gen rules reference CAI-only types, so reaching here always
+        # means those types are absent from the built workspace.
         self.assertTrue(
             any(
                 gcpapi.CAI_PERMISSION_DENIED_TOKEN in rec.getMessage()
-                and rec.levelname == "INFO"
+                and rec.levelname == "WARNING"
                 for rec in captured.records
             ),
-            f"expected an INFO {gcpapi.CAI_PERMISSION_DENIED_TOKEN} log; got {captured.output}",
+            f"expected a WARNING {gcpapi.CAI_PERMISSION_DENIED_TOKEN} log; got {captured.output}",
         )
-        # No ERROR severity for the CAI-denied path, and no "DEGRADED" framing.
+        # Still non-fatal: no ERROR severity, no "DEGRADED" framing.
         self.assertFalse(
             any(rec.levelno >= 40 for rec in captured.records),  # >= ERROR
             f"CAI-denied must not log at ERROR; got {captured.output}",
         )
         self.assertNotIn("DEGRADED", joined_logs)
-        # The message frames CAI as optional and reassures it is not an error.
-        self.assertIn("optional", joined_logs.lower())
+        # The message names the resource type that went missing.
+        self.assertIn("gcp_sql_instances", joined_logs)
 
-        # CAI's absence must NOT surface a user-facing warning (it is normal).
-        self.assertFalse(
+        # The operator gets a user-facing warning naming the gap.
+        self.assertTrue(
             any(gcpapi.CAI_PERMISSION_DENIED_TOKEN in w for w in warnings),
-            f"CAI-denied must not add a warning; got {warnings}",
+            f"CAI-denied must add a warning naming the missing types; got {warnings}",
         )
 
         # Discovery still completed: the project anchor was written.


### PR DESCRIPTION
## Problem

A denied Cloud Asset Inventory (CAI) pass was reported as **"no action is needed"** in every case. At a customer this hid a completely broken GCP discovery: three consecutive workspace builds discovered **zero** GCP resources while the log told the operator everything was fine.

Real log line from a build where nothing worked:

> `GCP_CAI_PERMISSION_DENIED: ... The per-service typed SDK collectors ... continue to run normally. Enabling the Cloud Asset Inventory API with a CAI viewer role is optional ... it is not required, so no action is needed.`

The typed collectors had failed two lines earlier with the same auth error (`skipped_collector_error=2`, `typed=0`).

## Three defects

**1. `_is_permission_denied` misclassified credential outages as CAI denials.**

It ended in a best-effort string fallback:

```python
return "403" in text and "permission" in text
```

A Workload Identity token-minting failure — `Unable to generate access token; IAM returned 403 Forbidden: Permission 'iam.serviceAccounts.getAccessToken' denied` — matches both substrings. So a total auth outage, where the typed SDK collectors are *equally* dead, was filed as an absent optional accelerator.

Fixed with `_is_credentials_failure`, checked **first** — such a failure can arrive wrapped in any exception type, including a genuine `PermissionDenied`.

**2. `_note_cai_unavailable` claimed no action was needed — always wrongly.**

It is only reachable from inside `if generic_cai_types:`, i.e. only when generation rules reference resource types that have **no typed collector**. So whenever it fires, those types are genuinely missing from the built workspace. It is now a warning naming exactly which types were lost, plus a user-facing `context.add_warning`.

**3. The closing summary asserted success without checking for any.**

It claimed discovery "completed via the typed SDK collectors" whenever CAI was denied, without checking the typed pass returned anything. Now gated on `added_typed`.

## Behaviour preserved

When CAI is genuinely absent and the typed baseline works, nothing changes: still non-fatal, still no `ERROR`, discovery still continues and writes the project anchor.

## What an operator sees now

```
[WARNING] GCP_CAI_PERMISSION_DENIED: Cloud Asset Inventory was not accessible for GCP
project 'REDACTED' (403 The caller does not have permission). 4 resource type(s)
referenced by your generation rules have no typed SDK collector and were therefore NOT
discovered in this run: gcp_bigquery_datasets, gcp_compute_forwarding_rules,
gcp_functions_functions, gcp_functionsv2_functions. To discover them, enable the
cloudasset.googleapis.com API on the project and grant roles/cloudasset.viewer to the
discovery service account. Resource types served by a typed collector are unaffected.
```

## Tests

New `src/indexers/test_gcpapi_cai_reporting.py` (7 tests), written failing first. Covers the three real exception shapes seen in the field:

| Exception | Benign CAI denial? |
| --- | --- |
| WI token-minting failure | No |
| Genuine CAI IAM denial | Yes |
| VPC Service Controls block | No |

### One pre-existing test updated

`test_cai_403_is_informational_not_fatal` asserted the old INFO / no-warning contract, which contradicted its own class docstring:

> "a 403 must be surfaced **loudly** (not silently swallowed) ... so a degraded discovery cannot pass as a false green"

Its assertions are aligned with that stated intent. The non-fatal guarantees it protected (no `ERROR`, no `DEGRADED` framing, discovery continues) are kept.

## Verification

`441 passed`, 0 failures — full suite in `src/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017MusgvbdQxRozCvQaRCaqY