### PR TITLE
fix(gcp): resolve ADC for Apigee collectors and classify 403s correctly

### DIFF
--- a/.test/k8s/basic/Taskfile.yaml
+++ b/.test/k8s/basic/Taskfile.yaml
@@ -593,6 +593,7 @@ tasks:
         cd "$SRC_DIR" && python3 -m unittest \
           indexers.test_sqlite_resource_writer \
           indexers.test_azureapi_normalizers \
+          indexers.test_gcpapi_apigee \
           -v
     silent: false
 

--- a/docs/authoring/indexed-resources/aws-resource-catalog.md
+++ b/docs/authoring/indexed-resources/aws-resource-catalog.md
@@ -2,7 +2,7 @@
 
 Resource types the native `awsapi` indexer can discover. Use the canonical CloudQuery table name (or any listed alias) as the `resourceTypes` value in a generation rule. This page is the companion catalog for [`aws.md`](./aws.md); see that page for how to enable the indexer and what data each row carries.
 
-_1119 resource types - 3 typed (rich-payload), 1116 generic (Cloud Control envelope). Generated 2026-08-14 from `src/indexers/aws_resource_type_registry.yaml`._
+_1119 resource types - 3 typed (rich-payload), 1116 generic (Cloud Control envelope). Generated 2026-08-21 from `src/indexers/aws_resource_type_registry.yaml`._
 
 _Regenerate with `python scripts/aws/dump_aws_resource_catalog.py` after touching the registry or overrides; do not hand-edit this file._
 

--- a/docs/authoring/indexed-resources/azure-resource-catalog.md
+++ b/docs/authoring/indexed-resources/azure-resource-catalog.md
@@ -2,7 +2,7 @@
 
 Resource types the native `azureapi` indexer can discover. Use the canonical CloudQuery table name (or any listed alias) as the `resourceTypes` value in a generation rule. This page is the companion catalog for [`azure.md`](./azure.md); see that page for how to enable the indexer and what data each row carries.
 
-_619 resource types - 25 typed (rich-payload), 594 generic (basic envelope). Generated 2026-08-14 from `src/indexers/azure_resource_type_registry.yaml`._
+_619 resource types - 25 typed (rich-payload), 594 generic (basic envelope). Generated 2026-08-21 from `src/indexers/azure_resource_type_registry.yaml`._
 
 _Regenerate with `python scripts/azure/dump_azure_resource_catalog.py` after touching the registry or overrides; do not hand-edit this file._
 

--- a/docs/authoring/indexed-resources/gcp-resource-catalog.md
+++ b/docs/authoring/indexed-resources/gcp-resource-catalog.md
@@ -2,7 +2,7 @@
 
 Resource types the native `gcpapi` indexer can discover. Use the canonical CloudQuery table name (or any listed alias) as the `resourceTypes` value in a generation rule. This page is the companion catalog for [`gcp.md`](./gcp.md); see that page for how to enable the indexer and what data each row carries.
 
-_412 resource types - 21 typed (SDK collectors), 391 generic (Cloud Asset Inventory pass). Generated 2026-08-14 from `src/indexers/gcp_resource_type_registry.yaml`._
+_412 resource types - 21 typed (SDK collectors), 391 generic (Cloud Asset Inventory pass). Generated 2026-08-21 from `src/indexers/gcp_resource_type_registry.yaml`._
 
 _Regenerate with `python scripts/gcp/dump_gcp_resource_catalog.py` after touching the registry or overrides; do not hand-edit this file._
 

--- a/docs/authoring/indexed-resources/kubernetes-resource-catalog.md
+++ b/docs/authoring/indexed-resources/kubernetes-resource-catalog.md
@@ -2,7 +2,7 @@
 
 Built-in Kubernetes resource types the kubeapi indexer discovers.
 
-_Generated 2026-08-14 from `indexers/kubetypes.py`._
+_Generated 2026-08-21 from `indexers/kubetypes.py`._
 
 Custom CRDs are declared in generation rules (`resourceTypes`) and indexed
 selectively — they are not listed here.

--- a/docs/authoring/indexed-resources/runwhen-platform-resource-catalog.md
+++ b/docs/authoring/indexed-resources/runwhen-platform-resource-catalog.md
@@ -2,7 +2,7 @@
 
 Resource types indexed under `platform: runwhen`.
 
-_Generated 2026-08-14 from `scripts/runwhen/dump_runwhen_resource_catalog.py`._
+_Generated 2026-08-21 from `scripts/runwhen/dump_runwhen_resource_catalog.py`._
 
 | Resource type | Match names | Typed collector | Notes |
 |---|---|---|---|

--- a/src/indexers/gcpapi.py
+++ b/src/indexers/gcpapi.py
@@ -189,6 +189,15 @@ def _is_permission_denied(exc: Exception) -> bool:
     REST ``Forbidden`` shapes, plus a string fallback."""
     if type(exc).__name__ in ("PermissionDenied", "Forbidden"):
         return True
+    # The Apigee collectors call the REST API directly and surface failures as a
+    # ``requests`` HTTPError, whose only machine-readable status lives on
+    # ``.response.status_code`` -- its class name is ``HTTPError`` and its string
+    # form ("403 Client Error: Forbidden for url: ...") never contains the word
+    # "permission", so none of the checks below would catch it. Duck-typed for
+    # the same reason the google exception types are not imported here.
+    status = getattr(getattr(exc, "response", None), "status_code", None)
+    if status in (401, 403):
+        return True
     code = getattr(exc, "code", None)
     # google.api_core PermissionDenied exposes code==403; grpc status objects
     # expose a callable .code(). Handle both without hard-depending on either.
@@ -336,6 +345,25 @@ def _discover_apigee(
             try:
                 items = list(collector(credentials, org_name))
             except Exception as e:
+                if _is_permission_denied(e):
+                    # An org is routinely readable while a subset of its
+                    # sub-resources (developers, apps, ...) is not. Treat that
+                    # the same way as an inaccessible Apigee API: informational,
+                    # not an error, so a partially-scoped role does not produce a
+                    # burst of warnings. Counted separately from
+                    # ``apigee_permission_denied`` so the run summary's "Apigee
+                    # API not accessible" note still means exactly that.
+                    stats["apigee_sub_permission_denied"] = (
+                        stats.get("apigee_sub_permission_denied", 0) + 1
+                    )
+                    logger.info(
+                        f"{APIGEE_PERMISSION_DENIED_TOKEN}: Apigee "
+                        f"{spec.resource_type_name} not accessible for org "
+                        f"{org_name} ({e}). This is informational; the rest of "
+                        f"Apigee discovery proceeds normally. To include this "
+                        f"resource type, grant roles/apigee.viewer."
+                    )
+                    continue
                 stats["skipped_collector_error"] += 1
                 logger.error(f"Failed to collect Apigee {spec.resource_type_name} for org {org_name}: {e}")
                 context.add_warning(f"Failed to collect Apigee {spec.resource_type_name} for org {org_name}: {e}")

--- a/src/indexers/gcpapi_resource_types.py
+++ b/src/indexers/gcpapi_resource_types.py
@@ -189,11 +189,45 @@ def _collect_iam_service_accounts(credentials, project_id):
 
 APIGEE_BASE_URL = "https://apigee.googleapis.com/v1"
 
+# Memo for the ADC credentials resolved by ``_ensure_apigee_credentials``. A
+# discovery run makes one organizations call plus one call per sub-collector per
+# org, and ``google.auth.default()`` re-walks the entire ADC discovery chain
+# (env var -> gcloud config -> metadata server) on every call. The credentials
+# object refreshes its own access token, so a single instance is safe to reuse
+# for the life of the process. Only successful resolutions are memoized, so a
+# transient DefaultCredentialsError is still retried on the next run.
+_ADC_CREDENTIALS = None
+
+
+def _ensure_apigee_credentials(credentials):
+    """Resolve Application Default Credentials when none were supplied.
+
+    ``gcp_get_credentials_and_projects`` returns ``credentials=None`` by design
+    when the workspace authenticates via ADC, leaving resolution to the
+    downstream client. Every other GCP collector honours that contract for free
+    because the ``google-cloud-*`` clients resolve ADC internally when handed
+    ``None``. The Apigee collectors are the only ones on the raw-REST path, and
+    ``AuthorizedSession`` has no ADC fallback -- it stores the ``None`` and
+    dereferences it on the first request ('NoneType' object has no attribute
+    'before_request'). So ADC has to be resolved explicitly here.
+    """
+    if credentials is not None:
+        return credentials
+
+    global _ADC_CREDENTIALS
+    if _ADC_CREDENTIALS is None:
+        import google.auth  # noqa: WPS433 (lazy import)
+
+        _ADC_CREDENTIALS, _ = google.auth.default(
+            scopes=["https://www.googleapis.com/auth/cloud-platform"]
+        )
+    return _ADC_CREDENTIALS
+
 
 def _apigee_api_get(credentials, path, *, params=None):
     from google.auth.transport.requests import AuthorizedSession
 
-    session = AuthorizedSession(credentials)
+    session = AuthorizedSession(_ensure_apigee_credentials(credentials))
     url = f"{APIGEE_BASE_URL}/{path.lstrip('/')}"
     response = session.get(url, params=params)
     response.raise_for_status()

--- a/src/indexers/test_gcpapi_apigee.py
+++ b/src/indexers/test_gcpapi_apigee.py
@@ -1,0 +1,317 @@
+"""
+Unit tests for the Apigee discovery path (``indexers.gcpapi_resource_types``
+and the Apigee branch of ``indexers.gcpapi``).
+
+Coverage:
+* ``_apigee_api_get`` resolves Application Default Credentials when handed
+  ``credentials=None``. This is the regression test for the ADC crash
+  ("'NoneType' object has no attribute 'before_request'"): unlike the
+  ``google-cloud-*`` clients, ``AuthorizedSession`` has no ADC fallback, and
+  ``gcp_get_credentials_and_projects`` returns ``None`` by design under ADC.
+* Explicitly supplied credentials are passed through untouched (no ADC lookup).
+* ``_is_permission_denied`` recognises the ``requests``-shaped HTTP error the
+  raw-REST Apigee collectors raise, without regressing the gRPC
+  ``PermissionDenied`` / REST ``Forbidden`` / numeric-code shapes.
+* A 403 on the organizations call takes the informational
+  ``apigee_permission_denied`` path rather than the hard-error path.
+* A 403 on a single sub-collector does not turn into a context warning.
+
+Everything is driven through stubs, so no GCP SDK call or network access is
+needed.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import sys
+from contextlib import ExitStack
+from unittest import TestCase, mock
+
+import requests
+
+_THIS_DIR = os.path.dirname(os.path.abspath(__file__))
+_SRC_DIR = os.path.dirname(_THIS_DIR)
+if _SRC_DIR not in sys.path:
+    sys.path.insert(0, _SRC_DIR)
+
+from indexers import gcpapi, gcpapi_resource_types  # noqa: E402
+from indexers.gcpapi_resource_types import GcpResourceTypeSpec  # noqa: E402
+
+_AUTHORIZED_SESSION = "google.auth.transport.requests.AuthorizedSession"
+
+
+def _http_error(status_code: int) -> requests.exceptions.HTTPError:
+    """Build the exception ``_apigee_api_get`` actually raises for a non-2xx:
+    ``response.raise_for_status()`` on a ``requests`` response."""
+    response = requests.Response()
+    response.status_code = status_code
+    response.reason = "Forbidden" if status_code == 403 else "Error"
+    response.url = "https://apigee.googleapis.com/v1/organizations"
+    try:
+        response.raise_for_status()
+    except requests.exceptions.HTTPError as exc:
+        return exc
+    raise AssertionError(f"status {status_code} did not raise")
+
+
+def _fake_session(payload):
+    session = mock.MagicMock()
+    session.get.return_value.json.return_value = payload
+    return session
+
+
+def _authorized_session_factory(payload):
+    """Stand-in for ``AuthorizedSession`` that reproduces its real behaviour on
+    ``None`` credentials: the constructor accepts them and the first request
+    dereferences them (``credentials.before_request(...)``)."""
+
+    def _factory(credentials):
+        if credentials is None:
+            session = mock.MagicMock()
+            session.get.side_effect = AttributeError(
+                "'NoneType' object has no attribute 'before_request'"
+            )
+            return session
+        return _fake_session(payload)
+
+    return _factory
+
+
+class ApigeeCredentialsTests(TestCase):
+    """``_apigee_api_get`` must work under both auth shapes."""
+
+    def setUp(self):
+        # The resolved-ADC memo is module state; keep tests independent of each
+        # other (and of whatever ran before them).
+        gcpapi_resource_types._ADC_CREDENTIALS = None
+        self.addCleanup(setattr, gcpapi_resource_types, "_ADC_CREDENTIALS", None)
+
+    def test_none_credentials_resolve_adc(self):
+        """Regression test: ADC auth hands the collectors ``credentials=None``
+        and ``AuthorizedSession(None)`` crashes on the first request."""
+        adc = mock.sentinel.adc_credentials
+        session = _fake_session({"organizations": [{"organization": "organizations/o"}]})
+
+        with mock.patch("google.auth.default", return_value=(adc, "proj")) as m_default, \
+                mock.patch(_AUTHORIZED_SESSION, return_value=session) as m_session:
+            body = gcpapi_resource_types._apigee_api_get(None, "organizations")
+
+        m_default.assert_called_once()
+        m_session.assert_called_once_with(adc)
+        self.assertEqual(body, {"organizations": [{"organization": "organizations/o"}]})
+
+    def test_explicit_credentials_passed_through(self):
+        creds = mock.sentinel.service_account_credentials
+        session = _fake_session({"organizations": []})
+
+        with mock.patch("google.auth.default") as m_default, \
+                mock.patch(_AUTHORIZED_SESSION, return_value=session) as m_session:
+            gcpapi_resource_types._apigee_api_get(creds, "organizations")
+
+        m_default.assert_not_called()
+        m_session.assert_called_once_with(creds)
+
+    def test_adc_resolved_once_across_calls(self):
+        """One org call plus seven sub-collector calls per org: ADC must not be
+        re-resolved on every request."""
+        adc = mock.sentinel.adc_credentials
+        session = _fake_session({})
+
+        with mock.patch("google.auth.default", return_value=(adc, "proj")) as m_default, \
+                mock.patch(_AUTHORIZED_SESSION, return_value=session) as m_session:
+            gcpapi_resource_types._apigee_api_get(None, "organizations")
+            gcpapi_resource_types._apigee_api_get(None, "organizations/o/environments")
+            gcpapi_resource_types._apigee_api_get(None, "organizations/o/apis")
+
+        self.assertEqual(m_default.call_count, 1)
+        self.assertEqual(m_session.call_args_list, [mock.call(adc)] * 3)
+
+    def test_collector_under_adc_does_not_crash(self):
+        """The reported failure end to end: the organizations collector called
+        with the ``credentials=None`` that ADC auth produces."""
+        adc = mock.sentinel.adc_credentials
+        payload = {"organizations": [{"organization": "organizations/o"}]}
+
+        with mock.patch("google.auth.default", return_value=(adc, "proj")), \
+                mock.patch(
+                    _AUTHORIZED_SESSION,
+                    side_effect=_authorized_session_factory(payload),
+                ):
+            orgs = gcpapi_resource_types._collect_apigee_organizations(None, "")
+
+        self.assertEqual(orgs, [{"organization": "organizations/o"}])
+
+
+class IsPermissionDeniedTests(TestCase):
+    """``_is_permission_denied`` classifies every 403 shape the GCP indexer can
+    see, including the raw-REST one the Apigee collectors raise."""
+
+    def test_requests_http_error_403(self):
+        self.assertTrue(gcpapi._is_permission_denied(_http_error(403)))
+
+    def test_requests_http_error_401(self):
+        self.assertTrue(gcpapi._is_permission_denied(_http_error(401)))
+
+    def test_requests_http_error_404_is_not_permission_denied(self):
+        self.assertFalse(gcpapi._is_permission_denied(_http_error(404)))
+
+    def test_requests_http_error_500_is_not_permission_denied(self):
+        self.assertFalse(gcpapi._is_permission_denied(_http_error(500)))
+
+    def test_grpc_permission_denied_by_type_name(self):
+        exc = type("PermissionDenied", (Exception,), {})("denied")
+        self.assertTrue(gcpapi._is_permission_denied(exc))
+
+    def test_rest_forbidden_by_type_name(self):
+        exc = type("Forbidden", (Exception,), {})("forbidden")
+        self.assertTrue(gcpapi._is_permission_denied(exc))
+
+    def test_numeric_code_403(self):
+        exc = Exception("boom")
+        exc.code = 403
+        self.assertTrue(gcpapi._is_permission_denied(exc))
+
+    def test_callable_grpc_status_code(self):
+        status = type("StatusCode", (), {"name": "PERMISSION_DENIED"})()
+        exc = Exception("boom")
+        exc.code = lambda: status
+        self.assertTrue(gcpapi._is_permission_denied(exc))
+
+    def test_string_fallback(self):
+        self.assertTrue(
+            gcpapi._is_permission_denied(Exception("403 caller lacks permission"))
+        )
+
+    def test_unrelated_exception(self):
+        self.assertFalse(gcpapi._is_permission_denied(ValueError("nope")))
+
+
+class _RecordingContext:
+    """Minimal Context stand-in: only ``add_warning`` is exercised here."""
+
+    def __init__(self):
+        self.warnings: list[str] = []
+
+    def add_warning(self, message):
+        self.warnings.append(message)
+
+
+def _new_stats() -> dict:
+    """The subset of ``gcpapi.index``'s stats dict that ``_discover_apigee``
+    touches, initialised the same way."""
+    return {
+        "added": 0,
+        "added_apigee": 0,
+        "added_apigee_org": 0,
+        "skipped_tag_filter": 0,
+        "skipped_parse_error": 0,
+        "skipped_collector_error": 0,
+        "apigee_permission_denied": 0,
+    }
+
+
+def _spec(name: str) -> GcpResourceTypeSpec:
+    return GcpResourceTypeSpec(
+        resource_type_name=name,
+        cloudquery_table_name=name,
+        cai_asset_type=None,
+        mandatory=False,
+        typed=True,
+        collector=None,
+    )
+
+
+class DiscoverApigeePermissionDeniedTests(TestCase):
+    def _run(self, *, orgs_side_effect=None, orgs=None, sub_collectors=None,
+             context=None, stats=None):
+        handler = mock.MagicMock()
+        handler.parse_resource_data.return_value = ("org-a", "gcp/org-a", {})
+        with ExitStack() as stack:
+            stack.enter_context(
+                mock.patch.object(gcpapi, "find_spec", side_effect=_spec)
+            )
+            stack.enter_context(mock.patch.object(
+                gcpapi, "_collect_apigee_organizations",
+                side_effect=orgs_side_effect or (lambda c, p: list(orgs or [])),
+            ))
+            if sub_collectors is not None:
+                stack.enter_context(mock.patch.object(
+                    gcpapi, "_APIGEE_SUB_COLLECTORS", sub_collectors
+                ))
+            gcpapi._discover_apigee(
+                None, handler, mock.MagicMock(), {}, context, "gcp_adc", None,
+                None, None, {"proj-a"}, stats,
+            )
+
+    def test_organizations_403_is_informational(self):
+        stats = _new_stats()
+        context = _RecordingContext()
+        exc = _http_error(403)
+
+        with self.assertLogs("indexers.gcpapi", level=logging.INFO) as logs:
+            self._run(
+                orgs_side_effect=mock.Mock(side_effect=exc),
+                context=context, stats=stats,
+            )
+
+        self.assertEqual(stats["apigee_permission_denied"], 1)
+        self.assertEqual(stats["skipped_collector_error"], 0)
+        self.assertEqual(context.warnings, [])
+        self.assertTrue(
+            any(gcpapi.APIGEE_PERMISSION_DENIED_TOKEN in r.getMessage() for r in logs.records),
+            f"expected {gcpapi.APIGEE_PERMISSION_DENIED_TOKEN} at INFO, got {logs.output}",
+        )
+        self.assertEqual([r for r in logs.records if r.levelno >= logging.WARNING], [])
+
+    def test_organizations_non_403_is_still_a_hard_error(self):
+        stats = _new_stats()
+        context = _RecordingContext()
+
+        self._run(
+            orgs_side_effect=mock.Mock(side_effect=RuntimeError("connection reset")),
+            context=context, stats=stats,
+        )
+
+        self.assertEqual(stats["skipped_collector_error"], 1)
+        self.assertEqual(stats["apigee_permission_denied"], 0)
+        self.assertEqual(len(context.warnings), 1)
+
+    def test_sub_collector_403_does_not_warn(self):
+        """Apigee orgs commonly 403 a subset of sub-resources (developers, apps)
+        while the org itself is readable; that must not produce a warning burst."""
+        stats = _new_stats()
+        context = _RecordingContext()
+        exc = _http_error(403)
+
+        def _denied(credentials, org_name):
+            raise exc
+
+        self._run(
+            orgs=[{"organization": "organizations/org-a", "projectId": "proj-a"}],
+            sub_collectors={"gcp_apigee_developers": _denied},
+            context=context, stats=stats,
+        )
+
+        self.assertEqual(context.warnings, [])
+        self.assertEqual(stats["skipped_collector_error"], 0)
+        self.assertEqual(stats.get("apigee_sub_permission_denied"), 1)
+        # The org itself was readable, so the "Apigee API not accessible"
+        # summary flag must stay clear.
+        self.assertEqual(stats["apigee_permission_denied"], 0)
+
+    def test_sub_collector_non_403_still_warns(self):
+        stats = _new_stats()
+        context = _RecordingContext()
+
+        def _boom(credentials, org_name):
+            raise RuntimeError("connection reset")
+
+        self._run(
+            orgs=[{"organization": "organizations/org-a", "projectId": "proj-a"}],
+            sub_collectors={"gcp_apigee_developers": _boom},
+            context=context, stats=stats,
+        )
+
+        self.assertEqual(stats["skipped_collector_error"], 1)
+        self.assertEqual(len(context.warnings), 1)


### PR DESCRIPTION
## Summary

Apigee discovery has failed on **every run** for GCP workspaces authenticating via Application Default Credentials since **0.11.10**:

```
ERROR    Failed to list Apigee organizations: 'NoneType' object has no attribute 'before_request'
INFO     GCP indexing complete: ... apigee=0, skipped_collector_error=1, apigee_permission_denied=0
WARNING  Failed to list Apigee organizations: 'NoneType' object has no attribute 'before_request'
```

Every other collector on the same run succeeded with the same credentials object (compute, storage, GKE, CAI). Only Apigee failed.

Regression origin: #823 (`6937912f`, "Add Apigee typed collectors and resource type registry entries"). 0.11.9 and earlier are unaffected only because the Apigee code did not exist — `gcp_apigee_organizations` was logged as an unknown resource type and skipped. **No runner has ever successfully discovered Apigee under ADC auth.**

## Root cause: an ADC-vs-service-account divergence

`gcp_get_credentials_and_projects()` (`src/indexers/gcp_common.py`) returns `credentials=None` **by design** when auth is ADC — no `saSecretName`, no `serviceAccountKey`, no `applicationCredentialsFile`. Its docstring states the contract explicitly: ADC is resolved by the downstream client.

### Why this affects Apigee and nothing else

It comes down to a two-line difference in what the two code paths do with a falsy `credentials`.

**Every other collector goes through a `google-cloud-*` client.** All 13 non-Apigee typed collectors plus the CAI pass construct an SDK client:

```
src/indexers/gcpapi_resource_types.py
  67  compute_v1.InstancesClient(credentials=credentials)
  77  storage.Client(project=project_id, credentials=credentials)
  84  container_v1.ClusterManagerClient(credentials=credentials)
 104  compute_v1.DisksClient(...)      114  SnapshotsClient(...)
 122  NetworksClient(...)              129  SubnetworksClient(...)
 139  FirewallsClient(...)             148  AddressesClient(...)
 159  pubsub_v1.PublisherClient(...)   168  SubscriberClient(...)
 177  iam_admin_v1.IAMClient(...)
 351  asset_v1.AssetServiceClient(credentials=credentials)
```

Those clients all bottom out in one of two base classes, and both contain an explicit ADC fallback:

```python
# google/api_core/grpc_helpers.py:241  — compute, container, pubsub, iam, asset
elif credentials:
    credentials = google.auth.credentials.with_scopes_if_required(...)
else:
    credentials, _ = google.auth.default(scopes=scopes, default_scopes=default_scopes)
```

```python
# google/cloud/client/__init__.py:197  — storage.Client
else:
    credentials, _ = google.auth.default(scopes=scopes)
```

So `credentials=None` is not an error to them — it is the *documented signal* to go resolve ADC. That is precisely the contract `gcp_get_credentials_and_projects()` was written against, and why its docstring says "the Cloud Asset client picks ADC up automatically". For 14 of the 15 code paths that assumption is correct and costs nothing.

**Apigee is the only raw-REST path.** The Apigee collectors never touch a `google-cloud-*` client. All 8 of them funnel through `_apigee_api_get`, which uses `AuthorizedSession` — a thin `requests.Session` subclass from `google-auth`, one layer *below* the client libraries. It has no equivalent branch:

```python
# google/auth/transport/requests.py:411  — constructor
self.credentials = credentials          # stored unconditionally, no None check

# google/auth/transport/requests.py:624  — first request
self.credentials.before_request(auth_request, method, url, request_headers)
```

`None` is accepted silently at construction and only blows up on the first outbound call, which is why the failure surfaces as a runtime `AttributeError` at request time rather than a clean auth error at setup:

```python
>>> AuthorizedSession(None).get("https://apigee.googleapis.com/v1/organizations")
AttributeError: 'NoneType' object has no attribute 'before_request'
```

### Why it looked like "only Apigee is broken"

The divergence is invisible under service-account auth, because there `credentials` is a real object and both paths behave identically. It appears only when `credentials is None`, which happens exclusively under ADC. That is also why the reported log shows 18 compute instances, 27 buckets, 1 GKE cluster and 53 CAI assets succeeding on the *same* credentials object that made Apigee crash — the other collectors were quietly re-resolving ADC for themselves inside the SDK, and Apigee had nobody to do that for it.

So the bug is not really "Apigee is special". `credentials=None` was an implicit contract honoured by a library, and #823 added the first consumer living below the layer that implements it. This PR restores the contract at that layer.

## Why CI did not catch it

Every GCP scenario in `.test/gcp/gcp-and-k8s/Taskfile.yaml` authenticates with `applicationCredentialsFile: /shared/gcp.secret`, fed the `GCP_SANDBOX_SA_JSON` service-account key by `.github/workflows/test-cloud-indexers.yaml`. So `credentials` is always non-`None` in CI and the ADC path is never exercised. This PR closes that gap with unit tests rather than another CI scenario — see the note on the wider CI gap at the bottom.

## Changes

**1. Resolve ADC explicitly on the REST path** — `src/indexers/gcpapi_resource_types.py`

New `_ensure_apigee_credentials()` resolves `google.auth.default()` when `credentials is None`, called from `_apigee_api_get` before constructing the session. It keeps the file's lazy-import discipline for google deps. The result is memoized at module scope: a run makes one organizations call plus one call per sub-collector per org (8+ per org), and `google.auth.default()` re-walks the whole discovery chain (env var → gcloud config → metadata server) on every call. Only successful resolutions are cached, so a transient `DefaultCredentialsError` is still retried on the next run — and a genuine one propagates into `_discover_apigee`'s existing `try/except` and is reported, as before.

The ADC-returns-`None` contract in `gcp_common.py` is left untouched; only the one consumer that mishandles it is fixed.

**2. Recognise the `requests` HTTP error shape** — `_is_permission_denied()` in `src/indexers/gcpapi.py`

With defect 1 fixed, projects that simply do not use Apigee would still be reported as hard errors. `_apigee_api_get` raises through `response.raise_for_status()`, producing:

```
requests.exceptions.HTTPError: 403 Client Error: Forbidden for url: https://apigee.googleapis.com/v1/organizations
```

`_is_permission_denied()` checked the class name (`PermissionDenied`/`Forbidden`), a numeric/callable `.code`, or `"403" in text and "permission" in text`. `HTTPError` matches none — its class name is `HTTPError`, it has no `.code`, and its string form never contains "permission". Verified: it returned `False`, so a benign "Apigee API not enabled / no access" took the `logger.error` + `context.add_warning` branch and incremented `skipped_collector_error` instead of the intended `_note_apigee_unavailable()` INFO note.

Now detected via duck-typed `getattr(exc, "response", None).status_code in (401, 403)` — no module-scope `requests` import, consistent with how the function already avoids importing google exception types.

**3. Classify sub-collector permission errors too** — `_discover_apigee` in `src/indexers/gcpapi.py`

The per-org sub-collector loop did not call `_is_permission_denied` at all; every failure became `logger.error` + `context.add_warning`. Apigee orgs commonly 403 a subset of sub-resources (`developers`, `apps`) while the org itself is readable, which produced a burst of spurious warnings. Same classification applied there — it was a small, clean change consistent with (2). Counted as a **separate** stat, `apigee_sub_permission_denied`, so the run summary's "Apigee API not accessible" note (driven by `apigee_permission_denied`) keeps meaning exactly that.

## Tests

New `src/indexers/test_gcpapi_apigee.py` — 18 tests, `unittest.TestCase` with the `sys.path` bootstrap header and `mock` stubs, matching `test_gcpapi_selective.py`. No GCP SDK call or network access. There were previously **zero** Apigee tests in the repo.

- `_apigee_api_get(None, ...)` resolves ADC and constructs `AuthorizedSession` with the resolved credentials, not `None` — the direct regression test. Its end-to-end sibling stubs `AuthorizedSession` with a fake that reproduces the real `None` behaviour (raises `'NoneType' object has no attribute 'before_request'` on first request), so the test genuinely fails on the old code rather than passing trivially against a mock.
- Explicit credentials pass through unchanged, with no `google.auth.default` call.
- ADC resolved once across repeated calls.
- `_is_permission_denied`: `requests` 403 and 401 → `True`; 404 and 500 → `False`; and the pre-existing gRPC `PermissionDenied`, REST `Forbidden`, numeric `code == 403`, callable gRPC status, string-fallback, and unrelated-exception cases all still classify as before.
- `_discover_apigee` with a 403 on the organizations call: `apigee_permission_denied == 1`, `skipped_collector_error` unchanged, no context warning, and the `GCP_APIGEE_PERMISSION_DENIED` token logged at INFO with nothing at WARNING or above.
- Non-403 org failures are still hard errors (warning + `skipped_collector_error`), and the same pair of cases for sub-collectors.

Tests were written first and confirmed failing against the unfixed source (**6 failures + 1 error**), then the fix applied:

```
=== BEFORE FIX (source reverted, final tests) ===
ERROR: test_collector_under_adc_does_not_crash    AttributeError: 'NoneType' object has no attribute 'before_request'
FAIL:  test_adc_resolved_once_across_calls
FAIL:  test_none_credentials_resolve_adc
FAIL:  test_organizations_403_is_informational
FAIL:  test_sub_collector_403_does_not_warn
FAIL:  test_requests_http_error_401
FAIL:  test_requests_http_error_403
Ran 18 tests in 0.013s
FAILED (failures=6, errors=1)

=== AFTER FIX: new Apigee tests ===
Ran 18 tests in 0.014s
OK

=== AFTER FIX: existing GCP unit tests ===
(test_gcpapi_selective, test_gcpapi_normalizers, test_gcp_resource_type_registry)
Ran 58 tests in 3.591s
OK

=== AFTER FIX: full indexers suite ===
Ran 301 tests in 17.039s
OK
```

The crash path was also re-verified against the **real** `AuthorizedSession` (only `google.auth.default` and the HTTP transport stubbed):

```
raw AuthorizedSession(None)      -> AttributeError: 'NoneType' object has no attribute 'before_request'
_ensure_apigee_credentials(None) -> <AdcCredentials>
real AuthorizedSession(resolved) -> constructed OK, credentials is None? False
_apigee_api_get(None, ...)       -> {'organizations': []}
```

## Notes for reviewers

- **Not verified locally:** a live ADC call against `apigee.googleapis.com`. No GCP credentials are available in this environment, so `google.auth.default()` was stubbed throughout. What is verified is that the resolved credentials reach a real `AuthorizedSession` and that the `None` dereference is gone.
- **No `src/VERSION` bump.** `CONTRIBUTING.md` is silent on version bumps, and the recent convention is mixed — #823 (the commit this fixes), #825 and #828 did not bump it; a maintainer landed a separate "version bump" commit afterwards. Happy to add one if you'd prefer it in this PR.
- **Wider CI gap, flagged not fixed:** no GitHub workflow runs the Python unit tests at all. The only runner is the `unit-test-src` target in `.test/k8s/basic/Taskfile.yaml`, which hand-lists two modules and is not invoked by any workflow. I added `indexers.test_gcpapi_apigee` to that list so the regression test is at least reachable, but wiring a unit-test job into CI is a separate change and is out of scope here.
- The `gcloud` not-found INFO line (`Error retrieving project name for ...: [Errno 2] No such file or directory: 'gcloud'`) seen on the same runner is a separate cosmetic issue in `enrichers/gcp.py` and is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017HiQwUx8eMSuQd8WzN3KaS

