### PR TITLE
ci: restrict image publish and sandbox deploy to main

### DIFF
--- a/.github/workflows/merge_to_main.yaml
+++ b/.github/workflows/merge_to_main.yaml
@@ -82,15 +82,26 @@ jobs:
       - name: Build & push linux/amd64
         run: |
           cd src
+          GAR="${{ env.SHARED_ARTIFACT_REPOSITORY_PATH }}/${{ env.IMAGE }}"
+          GHCR="ghcr.io/${{ env.GHCR_ORG }}/${{ env.IMAGE }}"
+          # Only main may claim the release tags. workflow_dispatch accepts any
+          # ref, so without this a test build from a feature branch overwrites
+          # the published ${VERSION} and latest images.
+          if [ "$GITHUB_REF" = "refs/heads/main" ]; then
+            TAGS=( --tag "${GAR}:${VERSION}-amd64" --tag "${GAR}:latest-amd64" \
+                   --tag "${GHCR}:${VERSION}-amd64" --tag "${GHCR}:latest-amd64" )
+          else
+            SAFE_REF=$(printf '%s' "$GITHUB_REF_NAME" | tr '/' '-' | tr -cd '[:alnum:]._-')
+            PRE="branch-${SAFE_REF}-${GITHUB_SHA::8}"
+            echo "::notice::Non-main ref: publishing ${PRE}-amd64 instead of ${VERSION}-amd64/latest-amd64"
+            TAGS=( --tag "${GAR}:${PRE}-amd64" --tag "${GHCR}:${PRE}-amd64" )
+          fi
           docker buildx create --use --name mybuilder || docker buildx use mybuilder
           docker buildx inspect --bootstrap
           docker buildx build \
             --platform linux/amd64 \
             --push \
-            --tag "${{ env.SHARED_ARTIFACT_REPOSITORY_PATH }}/${{ env.IMAGE }}:${VERSION}-amd64" \
-            --tag "${{ env.SHARED_ARTIFACT_REPOSITORY_PATH }}/${{ env.IMAGE }}:latest-amd64" \
-            --tag "ghcr.io/${{ env.GHCR_ORG }}/${{ env.IMAGE }}:${VERSION}-amd64" \
-            --tag "ghcr.io/${{ env.GHCR_ORG }}/${{ env.IMAGE }}:latest-amd64" \
+            "${TAGS[@]}" \
             --cache-from type=gha \
             --cache-to type=gha,mode=max \
             --build-arg GITHUB_SHA="$GITHUB_SHA" \
@@ -125,23 +136,35 @@ jobs:
       - name: Build & push linux/arm64
         run: |
           cd src
+          GAR="${{ env.SHARED_ARTIFACT_REPOSITORY_PATH }}/${{ env.IMAGE }}"
+          GHCR="ghcr.io/${{ env.GHCR_ORG }}/${{ env.IMAGE }}"
+          # See the amd64 job: only main may claim the release tags.
+          if [ "$GITHUB_REF" = "refs/heads/main" ]; then
+            TAGS=( --tag "${GAR}:${VERSION}-arm64" --tag "${GAR}:latest-arm64" \
+                   --tag "${GHCR}:${VERSION}-arm64" --tag "${GHCR}:latest-arm64" )
+          else
+            SAFE_REF=$(printf '%s' "$GITHUB_REF_NAME" | tr '/' '-' | tr -cd '[:alnum:]._-')
+            PRE="branch-${SAFE_REF}-${GITHUB_SHA::8}"
+            echo "::notice::Non-main ref: publishing ${PRE}-arm64 instead of ${VERSION}-arm64/latest-arm64"
+            TAGS=( --tag "${GAR}:${PRE}-arm64" --tag "${GHCR}:${PRE}-arm64" )
+          fi
           docker buildx create --use --name mybuilder || docker buildx use mybuilder
           docker buildx inspect --bootstrap
           docker buildx build \
             --platform linux/arm64 \
             --push \
-            --tag "${{ env.SHARED_ARTIFACT_REPOSITORY_PATH }}/${{ env.IMAGE }}:${VERSION}-arm64" \
-            --tag "${{ env.SHARED_ARTIFACT_REPOSITORY_PATH }}/${{ env.IMAGE }}:latest-arm64" \
-            --tag "ghcr.io/${{ env.GHCR_ORG }}/${{ env.IMAGE }}:${VERSION}-arm64" \
-            --tag "ghcr.io/${{ env.GHCR_ORG }}/${{ env.IMAGE }}:latest-arm64" \
+            "${TAGS[@]}" \
             --cache-from type=gha \
             --cache-to type=gha,mode=max \
             --build-arg GITHUB_SHA="$GITHUB_SHA" \
             --build-arg GITHUB_REF="$GITHUB_REF" \
             -f Dockerfile .
 
-  # Stitch the multi-arch tag when both are pushed
+  # Stitch the multi-arch tag when both are pushed.
+  # main only: this is the job that claims :${VERSION} and :latest, so a
+  # workflow_dispatch from a feature branch must never reach it.
   publish-manifest:
+    if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     needs: [build-amd64, build-arm64]
     permissions:
@@ -200,8 +223,12 @@ jobs:
         env:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
 
-  # Deploy to sandbox after successful build
+  # Deploy to sandbox after successful build.
+  # main only. Redundant with publish-manifest's guard (a skipped `needs` skips
+  # this too), but stated explicitly so the constraint is visible on the job
+  # that actually mutates the sandbox.
   deploy-to-sandbox:
+    if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     needs: [publish-manifest]
     env:


### PR DESCRIPTION
## Problem

`.github/workflows/merge_to_main.yaml` ("Build and Tag Image") accepts `workflow_dispatch`:

```yaml
on:
  workflow_dispatch:
  push:
    branches: [main]
    paths: ["src/VERSION", ".github/workflows/merge_to_main.yaml"]
```

The `push` trigger is correctly scoped to `main`. `workflow_dispatch` is not — it accepts any ref, and **no job checked the ref**. So dispatching this workflow from a feature branch ran the entire production pipeline against that branch's code:

- `build-amd64` / `build-arm64` push `:${VERSION}-<arch>` **and** `:latest-<arch>` to both `us-docker.pkg.dev/runwhen-nonprod-shared/public-images/runwhen-local` and `ghcr.io/runwhen-contrib/runwhen-local`
- `publish-manifest` stitches those into `:${VERSION}` and `:latest` on both registries
- `deploy-to-sandbox` runs `kubectl rollout restart` on the sandbox deployment
- three Slack notifications announce the push and deploy as if it were a release

## This already happened

Run [32486548128](https://github.com/runwhen-contrib/runwhen-local/actions/runs/32486548128) was dispatched from `emdash/apigee-discovery-failing-7i8ew` (PR #832). Its first attempt failed in `build-amd64` on a transient `proxy.golang.org` error, which incidentally skipped `publish-manifest` and `deploy-to-sandbox`. On re-run those jobs completed, and:

| tag | before | after |
|---|---|---|
| `:latest` and `:0.11.12`, both registries | `sha256:ee442599…` (main @ `bfda1020`) | `sha256:4c0c1b7e…` (PR branch @ `f0a3721e`) |

Because `src/VERSION` had not been bumped on that branch, this overwrote an **already-released** `0.11.12` tag, not just `latest`. The sandbox was then restarted onto it. The tags are being restored separately; this PR stops it recurring.

## Change

**1. Guard the two jobs that publish and deploy.**

```yaml
publish-manifest:
  if: github.ref == 'refs/heads/main'

deploy-to-sandbox:
  if: github.ref == 'refs/heads/main'
```

`deploy-to-sandbox`'s guard is redundant — it `needs: [publish-manifest]`, and a skipped dependency skips it too — but it is stated explicitly so the constraint is visible on the job that actually mutates the sandbox rather than only implied from a neighbour.

**2. Keep branch builds possible, but off the release tags.**

Guarding `publish-manifest` alone would still leave `:latest-amd64` / `:latest-arm64` and `:${VERSION}-<arch>` clobbered by a branch dispatch. Verifying that the image builds is a legitimate reason to dispatch from a branch, so rather than blocking the build jobs, their tags are now ref-dependent:

```
ref = refs/heads/main
  --tag …/runwhen-local:0.11.12-amd64
  --tag …/runwhen-local:latest-amd64
  --tag ghcr.io/runwhen-contrib/runwhen-local:0.11.12-amd64
  --tag ghcr.io/runwhen-contrib/runwhen-local:latest-amd64

ref = refs/heads/emdash/apigee-discovery-failing-7i8ew
  --tag …/runwhen-local:branch-emdash-apigee-discovery-failing-7i8ew-f0a3721e-amd64
  --tag ghcr.io/runwhen-contrib/runwhen-local:branch-emdash-apigee-discovery-failing-7i8ew-f0a3721e-amd64
```

A non-main run also emits a `::notice::` naming the substitute tag, so it is obvious in the run summary which tag was published.

`notify` is deliberately left unguarded: it is `if: always()` and its message already names the branch, so it stays useful for branch dispatches.

## Verification

Not yet exercised on GitHub — the change only takes effect once it is on `main`, and dispatching this workflow is precisely the operation under discussion, so I did not test it by dispatching it. What was checked locally:

- The workflow parses, and the guards land on the intended jobs:
  ```
  YAML OK; jobs: ['scan-repo', 'build-amd64', 'build-arm64', 'publish-manifest', 'deploy-to-sandbox', 'notify']
    publish-manifest   if="github.ref == 'refs/heads/main'"
    deploy-to-sandbox  if="github.ref == 'refs/heads/main'"
    build-amd64        if=None
    build-arm64        if=None
    notify             if='always()'
    scan-repo          if=None
  ```
- The tag-selection block was extracted and executed against both ref shapes, producing the tag lists shown above.
- `shellcheck -S warning` is clean on the rewritten build step (`TAGS` is a bash array expanded as `"${TAGS[@]}"`, so no word-splitting hazard; GitHub `run:` steps use bash on both runners).

Worth a reviewer's eye on whether `branch-<ref>-<sha8>` is the tag shape you want, and whether those branch tags should have a retention/cleanup policy so they do not accumulate in the registries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017HiQwUx8eMSuQd8WzN3KaS
