### PR TITLE
chore: bump version to 0.11.13

### DIFF
--- a/src/VERSION
+++ b/src/VERSION
@@ -1,4 +1,4 @@
 {
   "name": "runwhen-local",
-  "version": "0.11.12"
+  "version": "0.11.13"
 }


### PR DESCRIPTION
## What this does

Bumps `src/VERSION` from `0.11.12` to `0.11.13`. One line:

```diff
 {
   "name": "runwhen-local",
-  "version": "0.11.12"
+  "version": "0.11.13"
 }
```

## Why it's needed

#832 (the Apigee ADC fix) is merged to `main` as `309a10b4`, but **unreleased**. Both release workflows are path-filtered on `src/VERSION`:

```yaml
push:
  branches: [main]
  paths: ["src/VERSION", ".github/workflows/<name>.yaml"]
```

So merging the fix by itself tagged nothing, released nothing, and built no image. This commit is the trigger.

## What merging this will do

Landing this on `main` starts both pipelines automatically:

- **Semantic Versioning** → `git tag v0.11.13`, pushes it, `gh release create v0.11.13 --generate-notes`
- **Build and Tag Image** → builds from `main`, pushes `:0.11.13` and `:latest` to `us-docker.pkg.dev/runwhen-nonprod-shared/public-images/runwhen-local` and `ghcr.io/runwhen-contrib/runwhen-local`, then `kubectl rollout restart` on the sandbox deployment

## What ships in 0.11.13

```
309a10b4 fix(gcp): resolve ADC for Apigee collectors and classify 403s correctly (#832)
50a5c85b chore(renovate): enable automerge for low-risk (minor/patch/pin/digest) updates
```

Patch bump is the right level: the only functional change is a bugfix, with no API, config, or behaviour change beyond Apigee discovery now working under ADC auth. It fixes a crash that affected **every** ADC-auth GCP workspace on 0.11.10+ (`'NoneType' object has no attribute 'before_request'`), so it is worth releasing rather than waiting to batch.

## Side effect worth knowing

`:latest` and `:0.11.12` currently point at `sha256:75524bb8…` — a build published from the #832 *branch* by a `workflow_dispatch` on Aug 25, not from `main`. Merging this **corrects `:latest`**, which will be overwritten by a genuine `main` build.

It does **not** correct `:0.11.12`, which will keep pointing at a branch build of code that was never part of the 0.11.12 release. Re-pointing that tag back to its original `sha256:ee442599…` is a separate manual step.

Related: #833 restricts publish/deploy to `main` so a branch dispatch can no longer claim the release tags. Merging that first is recommended, though it does not affect this release either way.

## Verification

- `jq -r .version src/VERSION` → `0.11.13` (this is exactly how both workflows read it)
- Parses as valid JSON; formatting, key order, and trailing newline byte-for-byte unchanged apart from the version string
- Diff is one line

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017HiQwUx8eMSuQd8WzN3KaS
